### PR TITLE
Faster, automatic handling of TypedArray instances

### DIFF
--- a/comlink.ts
+++ b/comlink.ts
@@ -413,7 +413,7 @@ export const Comlink = (function() {
       visited.add(value);
     yield {value, path};
 
-    let keys = Object.keys(value);
+    const keys = ArrayBuffer.isView(value) ? [] : Object.keys(value);
     for (const key of keys)
       yield* iterateAllProperties((value as any)[key], [...path, key], visited);
   }


### PR DESCRIPTION
Comlink is amazing. It would be even more amazing if it could detect transferable types automatically, and while attempting to make it do that I stumbled onto a performance gain.

Assuming `value` is a `TypedArray` instance, `Object.keys` will include the numeric indexes, which the existing code then iterates over. A 2mb `Uint8Array`, for example, results in 2 million unnecessary iterations. This change avoids those iterations AND lets you do stuff like `proxyThing.doStuff(myTypedArrayInstance)` and get buffer transfers for free. In my ad hoc testing this reduces the time it takes to send a 2mb buffer from 3.5 seconds to about 6ms.