### PR TITLE
Make Comlink compatible with GoogleChrome/proxy-polyfill

### DIFF
--- a/comlink.ts
+++ b/comlink.ts
@@ -162,7 +162,6 @@ export const Comlink = (function() {
 
   /* export */ function proxy(
     endpoint: Endpoint | Window,
-    callPath?: PropertyKey[],
     target?: any
   ): Proxy {
     if (isWindow(endpoint)) endpoint = windowEndpoint(endpoint);
@@ -185,7 +184,7 @@ export const Comlink = (function() {
         const result = response.data as InvocationResult;
         return unwrapValue(result.value);
       },
-      callPath,
+      [],
       target
     );
   }
@@ -447,7 +446,11 @@ export const Comlink = (function() {
           });
           return Promise.resolve(r).then.bind(r);
         } else {
-          return cbProxy(cb, callPath.concat(property));
+          return cbProxy(
+            cb,
+            callPath.concat(property),
+            (<any>_target)[property]
+          );
         }
       },
       set(_target, property, value, _proxy): boolean {

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -393,14 +393,8 @@ describe("Comlink in the same realm", function() {
   });
 
   it("can proxy with a given target", async function() {
-    const proxy = Comlink.proxy(this.port1, [], { value: {} });
+    const proxy = Comlink.proxy(this.port1, { value: {} });
     Comlink.expose({ value: 4 }, this.port2);
-    expect(await proxy.value).to.equal(4);
-  });
-
-  it("can proxy with a given call path", async function() {
-    const proxy = Comlink.proxy(this.port1, ["obj"]);
-    Comlink.expose({ obj: { value: 4 } }, this.port2);
     expect(await proxy.value).to.equal(4);
   });
 });

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -391,4 +391,16 @@ describe("Comlink in the same realm", function() {
     expect(await b).to.equal(5);
     expect(await c()).to.equal(6);
   });
+
+  it("can proxy with a given target", async function() {
+    const proxy = Comlink.proxy(this.port1, [], { value: {} });
+    Comlink.expose({ value: 4 }, this.port2);
+    expect(await proxy.value).to.equal(4);
+  });
+
+  it("can proxy with a given call path", async function() {
+    const proxy = Comlink.proxy(this.port1, ["obj"]);
+    Comlink.expose({ obj: { value: 4 } }, this.port2);
+    expect(await proxy.value).to.equal(4);
+  });
 });


### PR DESCRIPTION
Allow `Comlink.proxy` to be called with `callPath` and `target` parameters, so it can be used with [GoogleChrome/proxy-polyfill](https://github.com/GoogleChrome/proxy-polyfill) when native ES6 Proxy is unavailable.

Disclaimer: I have no experience with TypeScript or Karma. I hope that I used them properly :)