### PR TITLE
Ignore events without msg.callPath key in exposed message handler

### DIFF
--- a/comlink.ts
+++ b/comlink.ts
@@ -199,8 +199,7 @@ export const Comlink = (function() {
 
     activateEndpoint(endpoint);
     attachMessageHandler(endpoint, async function(event: MessageEvent) {
-      if (!event.data.id) return;
-      if (!(event.data.msg && event.data.msg.callPath)) return;
+      if (!event.data.id || !event.data.callPath) return;
       const irequest = event.data as InvocationRequest;
       let that = await irequest.callPath
         .slice(0, -1)

--- a/comlink.ts
+++ b/comlink.ts
@@ -200,6 +200,7 @@ export const Comlink = (function() {
     activateEndpoint(endpoint);
     attachMessageHandler(endpoint, async function(event: MessageEvent) {
       if (!event.data.id) return;
+      if (!(event.data.msg && event.data.msg.callPath)) return;
       const irequest = event.data as InvocationRequest;
       let that = await irequest.callPath
         .slice(0, -1)


### PR DESCRIPTION
This fix allows calling both `expose` and `proxy` for the same endpoint.
The attached message handler for `expose` should ignore messages without a `callPath` key in `event.data.msg`.