### PR TITLE
Wrap JSON.parse with a try...catch block.

### DIFF
--- a/messagechanneladapter.ts
+++ b/messagechanneladapter.ts
@@ -49,7 +49,12 @@ function hookup(
   };
 
   smc.addEventListener("message", (event: Event): void => {
-    const data = JSON.parse((event as MessageEvent).data) as Message;
+    let data = {} as Message;
+    try {
+      data = JSON.parse((event as MessageEvent).data) as Message;
+    } catch (e) {
+      return;
+    }
     if (!id) id = data.id;
     if (id !== data.id) return;
     const mcs = data.messageChannels.map(messageChannel => {


### PR DESCRIPTION
Silently ignore string messages which can't be parsed as a json.

This shouldn't happen if only Comlink uses the smc. However, if some other module uses it, it might happen. 
I encountered this error in a React-Native app,  where I received an empty message `{data: ""}` due to some random React-Native bug. In this case, it causes the app to crash.