### PR TITLE
Keep all error properties including stack and message

### DIFF
--- a/comlink.ts
+++ b/comlink.ts
@@ -146,9 +146,13 @@ const proxyTransferHandler: TransferHandler = {
 
 const throwTransferHandler = {
   canHandle: (obj: {}): Boolean => obj && (obj as any)[throwSymbol],
-  serialize: (obj: {}): {} => obj.toString() + "\n" + (obj as any).stack,
+  serialize: (obj: any): {} => {
+    const message = obj && obj.message;
+    const stack = obj && obj.stack;
+    return Object.assign({}, obj, { message, stack });
+  },
   deserialize: (obj: {}): {} => {
-    throw Error(obj as string);
+    throw Object.assign(Error(), obj);
   }
 };
 

--- a/dist/comlink.js
+++ b/dist/comlink.js
@@ -27,9 +27,13 @@ const proxyTransferHandler = {
 };
 const throwTransferHandler = {
     canHandle: (obj) => obj && obj[throwSymbol],
-    serialize: (obj) => obj.toString() + "\n" + obj.stack,
+    serialize: (obj) => {
+        const message = obj && obj.message;
+        const stack = obj && obj.stack;
+        return Object.assign({}, obj, { message, stack });
+    },
     deserialize: (obj) => {
-        throw Error(obj);
+        throw Object.assign(Error(), obj);
     }
 };
 export const transferHandlers = new Map([

--- a/dist/umd/comlink.js
+++ b/dist/umd/comlink.js
@@ -39,9 +39,13 @@ else {factory([], self.Comlink={});}
     };
     const throwTransferHandler = {
         canHandle: (obj) => obj && obj[throwSymbol],
-        serialize: (obj) => obj.toString() + "\n" + obj.stack,
+        serialize: (obj) => {
+            const message = obj && obj.message;
+            const stack = obj && obj.stack;
+            return Object.assign({}, obj, { message, stack });
+        },
         deserialize: (obj) => {
-            throw Error(obj);
+            throw Object.assign(Error(), obj);
         }
     };
     exports.transferHandlers = new Map([

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -101,19 +101,17 @@ describe("Comlink in the same realm", function() {
     expect(await proxy.x).to.be.undefined;
   });
 
-  it("can handle throwing functions", function(done) {
+  it("can handle throwing functions", async function() {
     const proxy = Comlink.proxy(this.port1);
     Comlink.expose(_ => {
       throw Error("OMG");
     }, this.port2);
-    proxy()
-      .then(_ => {
-        done(Error("Should have thrown"));
-      })
-      .catch(err => {
-        expect(err.toString()).to.contain("OMG");
-        done();
-      });
+    try {
+      await proxy();
+      fail("Should have thrown");
+    } catch (err) {
+      expect(err.toString()).to.contain("OMG");
+    }
   });
 
   it("can work with parameterized functions", async function() {

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -101,16 +101,33 @@ describe("Comlink in the same realm", function() {
     expect(await proxy.x).to.be.undefined;
   });
 
-  it("can handle throwing functions", async function() {
+  it("can keep the stack and message of thrown errors", async function() {
+    let stack;
     const proxy = Comlink.proxy(this.port1);
     Comlink.expose(_ => {
-      throw Error("OMG");
+      const error = Error("OMG");
+      stack = error.stack;
+      throw error;
     }, this.port2);
     try {
       await proxy();
       fail("Should have thrown");
     } catch (err) {
-      expect(err.toString()).to.contain("OMG");
+      expect(err.message).to.equal("OMG");
+      expect(err.stack).to.equal(stack);
+    }
+  });
+
+  it("can rethrow non-error objects", async function() {
+    const proxy = Comlink.proxy(this.port1);
+    Comlink.expose(_ => {
+      throw {test: true};
+    }, this.port2);
+    try {
+      await proxy();
+      fail("Should have thrown");
+    } catch (err) {
+      expect(err.test).to.equal(true);
     }
   });
 


### PR DESCRIPTION
This pull request changes comlink to retain the exact error `message` and `stack` of thrown errors. Previously, the message including stack trace was rethrown as the error's message and any additional properties were lost (see [my comment](https://github.com/GoogleChromeLabs/comlink/issues/140#issuecomment-401549674) on #140).

I tried not breaking the other edge cases (throw null, undefined, function, string, number), but testing that resulted in a timeout, so I'm assuming they already didn't work properly before this PR.
