### PR TITLE
Update readme to reflect that transferable function parameters are not structurally copied by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you invoke function, all parameters will be structurally cloned or transferre
 
 > Makes sure a parameter or return value is proxied, not copied.
 
-By default, all parameters to a function are copied (structural clone):
+By default, all parameters to a function that are not [transferable] are copied (structural clone):
 
 ```js
 // main.js


### PR DESCRIPTION
Maybe I got it all wrong, but to me the following two quotes from the readme seem to contradict themselves:

```
If you invoke function, all parameters will be structurally cloned or transferred if they are transferable.
```

```
By default, all parameters to a function are copied (structural clone):
```

I adapted the readme which hopefully fixes the contradiction. If not, please clear up my confusion which would ensue otherwise :)