### PR TITLE
Reference lib.dom.d.ts for Window type, fixes #123

### DIFF
--- a/comlink.ts
+++ b/comlink.ts
@@ -12,7 +12,6 @@
  */
 
 /// <reference lib="dom" />
-/// <reference lib="webworker" />
 
 export interface Endpoint {
   postMessage(message: any, transfer?: any[]): void;

--- a/comlink.ts
+++ b/comlink.ts
@@ -11,6 +11,9 @@
  * limitations under the License.
  */
 
+/// <reference lib="dom" />
+/// <reference lib="webworker" />
+
 export interface Endpoint {
   postMessage(message: any, transfer?: any[]): void;
   addEventListener(


### PR DESCRIPTION
This should fix the `Cannot find name 'Window'` error.