### PR TITLE
Typesafe nested method calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM selenium/node-chrome:latest@sha256:51bf5cb4ae3c854d33092e37428ac7da04326806
 USER root
 
 RUN apt-get update -qqy \
+  && apt-get install -y git \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && rm /bin/sh && ln -s /bin/bash /bin/sh \
   && chown seluser /usr/local

--- a/comlink.ts
+++ b/comlink.ts
@@ -58,7 +58,7 @@ type ProxiedObject<T> = {
   [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R
     ? (...args: Arguments) => Promisify<R>
     : (T[P] extends ProxyValue
-        ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>>
+        ? ProxiedObject<Omit<T[P], keyof ProxyValue>>
         : Promisify<T[P]>)
 };
 

--- a/comlink.ts
+++ b/comlink.ts
@@ -28,16 +28,44 @@ export interface Endpoint {
 // To avoid Promise<Promise<T>>
 type Promisify<T> = T extends Promise<any> ? T : Promise<T>;
 
-// ProxiedObject<T> is equivalent to T, except that all properties are now promises and
-// all functions now return promises. It effectively async-ifies an object.
+/**
+ * Symbol that gets added to objects by `Comlink.proxy()`.
+ */
+export const proxyValueSymbol = Symbol("comlinkProxyValue");
+
+/**
+ * Object that was wrapped with `Comlink.proxy()`.
+ */
+export interface ProxyValue {
+  [proxyValueSymbol]: true;
+}
+
+/**
+ * Returns true if the given value has the proxy value symbol added to it.
+ */
+const isProxyValue = (value: any): value is ProxyValue =>
+  !!value && value[proxyValueSymbol] === true;
+
+/** Helper that omits all keys K from object T */
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+/**
+ * `ProxiedObject<T>` is equivalent to `T`, except that all properties are now promises and
+ * all functions now return promises, except if they were wrapped with `Comlink.proxyValue()`.
+ * It effectively async-ifies an object.
+ */
 type ProxiedObject<T> = {
   [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R
     ? (...args: Arguments) => Promisify<R>
-    : Promisify<T[P]>
+    : (T[P] extends { [proxyValueSymbol]: true }
+        ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>>
+        : Promisify<T[P]>)
 };
 
-// ProxyResult<T> is an augmentation of ProxyObject<T> that also handles raw functions
-// and classes correctly.
+/**
+ * ProxyResult<T> is an augmentation of ProxyObject<T> that also handles raw functions
+ * and classes correctly.
+ */
 export type ProxyResult<T> = ProxiedObject<T> &
   (T extends (...args: infer Arguments) => infer R
     ? (...args: Arguments) => Promisify<R>
@@ -154,10 +182,9 @@ const TRANSFERABLE_TYPES = ["ArrayBuffer", "MessagePort", "OffscreenCanvas"]
   .map(f => (self as any)[f]);
 const uid: number = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 
-const proxyValueSymbol = Symbol("proxyValue");
 const throwSymbol = Symbol("throw");
 const proxyTransferHandler: TransferHandler = {
-  canHandle: (obj: {}): Boolean => obj && (obj as any)[proxyValueSymbol],
+  canHandle: isProxyValue,
   serialize: (obj: {}): {} => {
     const { port1, port2 } = new MessageChannel();
     expose(obj, port1);
@@ -216,9 +243,10 @@ export function proxy<T = any>(
   ) as ProxyResult<T>;
 }
 
-export function proxyValue<T>(obj: T): T {
-  (obj as any)[proxyValueSymbol] = true;
-  return obj;
+export function proxyValue<T>(obj: T): T & ProxyValue {
+  const proxyVal = obj as T & ProxyValue;
+  proxyVal[proxyValueSymbol] = true;
+  return proxyVal;
 }
 
 export function expose(rootObj: Exposable, endpoint: Endpoint | Window): void {

--- a/comlink.ts
+++ b/comlink.ts
@@ -57,7 +57,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 type ProxiedObject<T> = {
   [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R
     ? (...args: Arguments) => Promisify<R>
-    : (T[P] extends { [proxyValueSymbol]: true }
+    : (T[P] extends ProxyValue
         ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>>
         : Promisify<T[P]>)
 };

--- a/dist/comlink.d.ts
+++ b/dist/comlink.d.ts
@@ -45,7 +45,7 @@ declare type ProxiedObject<T> = {
   [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R
     ? (...args: Arguments) => Promisify<R>
     : (T[P] extends ProxyValue
-        ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>>
+        ? ProxiedObject<Omit<T[P], keyof ProxyValue>>
         : Promisify<T[P]>)
 };
 /**

--- a/dist/comlink.d.ts
+++ b/dist/comlink.d.ts
@@ -44,9 +44,7 @@ declare type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 declare type ProxiedObject<T> = {
   [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R
     ? (...args: Arguments) => Promisify<R>
-    : (T[P] extends {
-        [proxyValueSymbol]: true;
-      }
+    : (T[P] extends ProxyValue
         ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>>
         : Promisify<T[P]>)
 };

--- a/dist/comlink.d.ts
+++ b/dist/comlink.d.ts
@@ -23,20 +23,46 @@ export interface Endpoint {
     options?: {}
   ): void;
 }
+declare type Promisify<T> = T extends Promise<any> ? T : Promise<T>;
+/**
+ * Symbol that gets added to objects by `Comlink.proxy()`.
+ */
+export declare const proxyValueSymbol: unique symbol;
+/**
+ * Object that was wrapped with `Comlink.proxy()`.
+ */
+export interface ProxyValue {
+  [proxyValueSymbol]: true;
+}
+/** Helper that omits all keys K from object T */
+declare type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+/**
+ * `ProxiedObject<T>` is equivalent to `T`, except that all properties are now promises and
+ * all functions now return promises, except if they were wrapped with `Comlink.proxyValue()`.
+ * It effectively async-ifies an object.
+ */
 declare type ProxiedObject<T> = {
   [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R
-    ? (...args: Arguments) => Promise<R>
-    : Promise<T[P]>
+    ? (...args: Arguments) => Promisify<R>
+    : (T[P] extends {
+        [proxyValueSymbol]: true;
+      }
+        ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>>
+        : Promisify<T[P]>)
 };
+/**
+ * ProxyResult<T> is an augmentation of ProxyObject<T> that also handles raw functions
+ * and classes correctly.
+ */
 export declare type ProxyResult<T> = ProxiedObject<T> &
   (T extends (...args: infer Arguments) => infer R
-    ? (...args: Arguments) => Promise<R>
+    ? (...args: Arguments) => Promisify<R>
     : unknown) &
   (T extends {
     new (...args: infer ArgumentsType): infer InstanceType;
   }
     ? {
-        new (...args: ArgumentsType): Promise<ProxiedObject<InstanceType>>;
+        new (...args: ArgumentsType): Promisify<ProxiedObject<InstanceType>>;
       }
     : unknown);
 export declare type Proxy = Function;
@@ -51,7 +77,7 @@ export declare function proxy<T = any>(
   endpoint: Endpoint | Window,
   target?: any
 ): ProxyResult<T>;
-export declare function proxyValue<T>(obj: T): T;
+export declare function proxyValue<T>(obj: T): T & ProxyValue;
 export declare function expose(
   rootObj: Exposable,
   endpoint: Endpoint | Window

--- a/dist/comlink.js
+++ b/dist/comlink.js
@@ -10,14 +10,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Symbol that gets added to objects by `Comlink.proxy()`.
+ */
+export const proxyValueSymbol = Symbol("comlinkProxyValue");
+/**
+ * Returns true if the given value has the proxy value symbol added to it.
+ */
+const isProxyValue = (value) => !!value && value[proxyValueSymbol] === true;
 const TRANSFERABLE_TYPES = ["ArrayBuffer", "MessagePort", "OffscreenCanvas"]
     .filter(f => f in self)
     .map(f => self[f]);
 const uid = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
-const proxyValueSymbol = Symbol("proxyValue");
 const throwSymbol = Symbol("throw");
 const proxyTransferHandler = {
-    canHandle: (obj) => obj && obj[proxyValueSymbol],
+    canHandle: isProxyValue,
     serialize: (obj) => {
         const { port1, port2 } = new MessageChannel();
         expose(obj, port1);
@@ -59,8 +66,9 @@ export function proxy(endpoint, target) {
     }, [], target);
 }
 export function proxyValue(obj) {
-    obj[proxyValueSymbol] = true;
-    return obj;
+    const proxyVal = obj;
+    proxyVal[proxyValueSymbol] = true;
+    return proxyVal;
 }
 export function expose(rootObj, endpoint) {
     if (isWindow(endpoint))

--- a/dist/umd/comlink.d.ts
+++ b/dist/umd/comlink.d.ts
@@ -15,13 +15,37 @@ export interface Endpoint {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: {}): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: {}): void;
 }
+declare type Promisify<T> = T extends Promise<any> ? T : Promise<T>;
+/**
+ * Symbol that gets added to objects by `Comlink.proxy()`.
+ */
+export declare const proxyValueSymbol: unique symbol;
+/**
+ * Object that was wrapped with `Comlink.proxy()`.
+ */
+export interface ProxyValue {
+    [proxyValueSymbol]: true;
+}
+/** Helper that omits all keys K from object T */
+declare type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+/**
+ * `ProxiedObject<T>` is equivalent to `T`, except that all properties are now promises and
+ * all functions now return promises, except if they were wrapped with `Comlink.proxyValue()`.
+ * It effectively async-ifies an object.
+ */
 declare type ProxiedObject<T> = {
-    [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promise<R> : Promise<T[P]>;
+    [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promisify<R> : (T[P] extends {
+        [proxyValueSymbol]: true;
+    } ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>> : Promisify<T[P]>);
 };
-export declare type ProxyResult<T> = ProxiedObject<T> & (T extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promise<R> : unknown) & (T extends {
+/**
+ * ProxyResult<T> is an augmentation of ProxyObject<T> that also handles raw functions
+ * and classes correctly.
+ */
+export declare type ProxyResult<T> = ProxiedObject<T> & (T extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promisify<R> : unknown) & (T extends {
     new (...args: infer ArgumentsType): infer InstanceType;
 } ? {
-    new (...args: ArgumentsType): Promise<ProxiedObject<InstanceType>>;
+    new (...args: ArgumentsType): Promisify<ProxiedObject<InstanceType>>;
 } : unknown);
 export declare type Proxy = Function;
 export declare type Exposable = Function | Object;
@@ -32,6 +56,6 @@ export interface TransferHandler {
 }
 export declare const transferHandlers: Map<string, TransferHandler>;
 export declare function proxy<T = any>(endpoint: Endpoint | Window, target?: any): ProxyResult<T>;
-export declare function proxyValue<T>(obj: T): T;
+export declare function proxyValue<T>(obj: T): T & ProxyValue;
 export declare function expose(rootObj: Exposable, endpoint: Endpoint | Window): void;
 export {};

--- a/dist/umd/comlink.d.ts
+++ b/dist/umd/comlink.d.ts
@@ -34,9 +34,7 @@ declare type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
  * It effectively async-ifies an object.
  */
 declare type ProxiedObject<T> = {
-    [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promisify<R> : (T[P] extends {
-        [proxyValueSymbol]: true;
-    } ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>> : Promisify<T[P]>);
+    [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promisify<R> : (T[P] extends ProxyValue ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>> : Promisify<T[P]>);
 };
 /**
  * ProxyResult<T> is an augmentation of ProxyObject<T> that also handles raw functions

--- a/dist/umd/comlink.d.ts
+++ b/dist/umd/comlink.d.ts
@@ -34,7 +34,7 @@ declare type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
  * It effectively async-ifies an object.
  */
 declare type ProxiedObject<T> = {
-    [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promisify<R> : (T[P] extends ProxyValue ? ProxiedObject<Omit<T[P], typeof proxyValueSymbol>> : Promisify<T[P]>);
+    [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promisify<R> : (T[P] extends ProxyValue ? ProxiedObject<Omit<T[P], keyof ProxyValue>> : Promisify<T[P]>);
 };
 /**
  * ProxyResult<T> is an augmentation of ProxyObject<T> that also handles raw functions

--- a/dist/umd/comlink.js
+++ b/dist/umd/comlink.js
@@ -22,14 +22,21 @@ else {factory([], self.Comlink={});}
 })(function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
+    /**
+     * Symbol that gets added to objects by `Comlink.proxy()`.
+     */
+    exports.proxyValueSymbol = Symbol("comlinkProxyValue");
+    /**
+     * Returns true if the given value has the proxy value symbol added to it.
+     */
+    const isProxyValue = (value) => !!value && value[exports.proxyValueSymbol] === true;
     const TRANSFERABLE_TYPES = ["ArrayBuffer", "MessagePort", "OffscreenCanvas"]
         .filter(f => f in self)
         .map(f => self[f]);
     const uid = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
-    const proxyValueSymbol = Symbol("proxyValue");
     const throwSymbol = Symbol("throw");
     const proxyTransferHandler = {
-        canHandle: (obj) => obj && obj[proxyValueSymbol],
+        canHandle: isProxyValue,
         serialize: (obj) => {
             const { port1, port2 } = new MessageChannel();
             expose(obj, port1);
@@ -72,8 +79,9 @@ else {factory([], self.Comlink={});}
     }
     exports.proxy = proxy;
     function proxyValue(obj) {
-        obj[proxyValueSymbol] = true;
-        return obj;
+        const proxyVal = obj;
+        proxyVal[exports.proxyValueSymbol] = true;
+        return proxyVal;
     }
     exports.proxyValue = proxyValue;
     function expose(rootObj, endpoint) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/parsimmon": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
+      "integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -20,6 +26,18 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -28,6 +46,15 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -95,6 +122,32 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        }
+      }
     },
     "backo2": {
       "version": "1.0.2",
@@ -287,6 +340,12 @@
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -328,6 +387,37 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "check-error": {
@@ -395,6 +485,21 @@
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
       }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colors": {
       "version": "1.3.3",
@@ -560,6 +665,15 @@
         }
       }
     },
+    "definitelytyped-header-parser": {
+      "version": "github:Microsoft/definitelytyped-header-parser#e0561530379dfa01324a89936b75d90b20df9bd2",
+      "from": "github:Microsoft/definitelytyped-header-parser#production",
+      "dev": true,
+      "requires": {
+        "@types/parsimmon": "^1.3.0",
+        "parsimmon": "^1.2.0"
+      }
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -572,6 +686,12 @@
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "dom-serialize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
@@ -582,6 +702,27 @@
         "ent": "~2.2.0",
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
+      }
+    },
+    "dtslint": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.4.2.tgz",
+      "integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
+      "dev": true,
+      "requires": {
+        "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+        "fs-extra": "^6.0.1",
+        "strip-json-comments": "^2.0.1",
+        "tslint": "^5.12.0",
+        "typescript": "^3.4.0-dev.20190129"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.4.0-dev.20190129",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.0-dev.20190129.tgz",
+          "integrity": "sha512-g+SKJolDQQevfYOlDBCe+tjpN62m+9wos3+ZBdSMSbGoOTWeLevU/ZTIBzcLm/MMjOxYoXDzzYh/2mXxtnC/eA==",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -623,7 +764,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -680,6 +821,18 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "eventemitter3": {
@@ -753,7 +906,7 @@
     },
     "expand-range": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
       "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
       "dev": true,
       "requires": {
@@ -961,6 +1114,17 @@
       "dev": true,
       "requires": {
         "null-check": "^1.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -1576,6 +1740,15 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -1645,7 +1818,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -1699,7 +1872,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -1734,7 +1907,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -1853,6 +2026,31 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "karma": {
       "version": "4.0.0",
@@ -2016,7 +2214,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -2290,7 +2488,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -2318,6 +2516,12 @@
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
+    "parsimmon": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.12.0.tgz",
+      "integrity": "sha512-uC/BjuSfb4jfaWajKCp1mVncXXq+V1twbcYChbTxN3GM7fn+8XoHwUdvUz+PTaFtDSCRQxU8+Rnh+iMhAkVwdw==",
+      "dev": true
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -2334,6 +2538,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "pathval": {
@@ -2398,7 +2608,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -2456,6 +2666,15 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -2507,7 +2726,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -2518,6 +2737,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
     },
     "set-value": {
@@ -2728,7 +2953,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {
@@ -2788,6 +3013,12 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -2846,12 +3077,33 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -2908,6 +3160,41 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.27.2"
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
       }
     },
     "type-detect": {
@@ -2972,6 +3259,12 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "module": "comlink.js",
   "types": "comlink.d.ts",
   "scripts": {
-    "test": "npm run linter && npm run unittest && npm run build",
+    "test": "npm run linter && npm run dtslint && npm run unittest && npm run build",
     "unittest": "karma start",
     "linter": "prettier --write ./*.js ./docs/**/*.js ./tests/**/*.js ./**/*.ts ./**/*.md ./**/*.json",
+    "dtslint": "tslint --project tests/tsconfig.json --config tslint.json",
     "watchtest": "karma start --no-single-run --browsers ChromeHeadless",
     "watchtestharmony": "karma start --no-single-run --browsers ChromeCanaryHeadlessHarmony",
     "version": "sed -i.bak -e 's!comlinkjs@[0-9.]*!comlinkjs@'${npm_package_version}'!' README.md && git add README.md",
@@ -39,6 +40,7 @@
   "devDependencies": {
     "chai": "4.2.0",
     "karma": "4.0.0",
+    "dtslint": "^0.4.1",
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-firefox-launcher": "1.1.0",
@@ -47,6 +49,7 @@
     "karma-safaritechpreview-launcher": "2.0.2",
     "mocha": "5.2.0",
     "prettier": "1.16.1",
+    "tslint": "^5.12.1",
     "typescript": "3.2.4"
   },
   "dependencies": {}

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -121,7 +121,7 @@ describe("Comlink in the same realm", function() {
   it("can rethrow non-error objects", async function() {
     const proxy = Comlink.proxy(this.port1);
     Comlink.expose(_ => {
-      throw {test: true};
+      throw { test: true };
     }, this.port2);
     try {
       await proxy();
@@ -266,17 +266,21 @@ describe("Comlink in the same realm", function() {
     expect(await instance._counter).to.equal(4);
   });
 
-  const hasBroadcastChannel = _ => ('BroadcastChannel' in self);
-  guardedIt(hasBroadcastChannel)("will work with BroadcastChannel", async function() {
-    const b1 = new BroadcastChannel("comlink_bc_test");
-    const b2 = new BroadcastChannel("comlink_bc_test");
-    const proxy = Comlink.proxy(b1);
-    Comlink.expose(b => 40 + b, b2);
-    expect(await proxy(2)).to.equal(42);
-  });
+  const hasBroadcastChannel = _ => "BroadcastChannel" in self;
+  guardedIt(hasBroadcastChannel)(
+    "will work with BroadcastChannel",
+    async function() {
+      const b1 = new BroadcastChannel("comlink_bc_test");
+      const b2 = new BroadcastChannel("comlink_bc_test");
+      const proxy = Comlink.proxy(b1);
+      Comlink.expose(b => 40 + b, b2);
+      expect(await proxy(2)).to.equal(42);
+    }
+  );
 
   // Buffer transfers seem to have regressed in Safari 11.1, it’s fixed in 11.2.
-  const isNotSafari11_1 = _ => !/11\.1(\.[0-9]+)? Safari/.test(navigator.userAgent);
+  const isNotSafari11_1 = _ =>
+    !/11\.1(\.[0-9]+)? Safari/.test(navigator.userAgent);
   guardedIt(isNotSafari11_1)("will transfer buffers", async function() {
     const proxy = Comlink.proxy(this.port1);
     Comlink.expose(b => b.byteLength, this.port2);
@@ -285,13 +289,16 @@ describe("Comlink in the same realm", function() {
     expect(buffer.byteLength).to.equal(0);
   });
 
-  guardedIt(isNotSafari11_1)("will transfer deeply nested buffers", async function() {
-    const proxy = Comlink.proxy(this.port1);
-    Comlink.expose(a => a.b.c.d.byteLength, this.port2);
-    const buffer = new Uint8Array([1, 2, 3]).buffer;
-    expect(await proxy({ b: { c: { d: buffer } } })).to.equal(3);
-    expect(buffer.byteLength).to.equal(0);
-  });
+  guardedIt(isNotSafari11_1)(
+    "will transfer deeply nested buffers",
+    async function() {
+      const proxy = Comlink.proxy(this.port1);
+      Comlink.expose(a => a.b.c.d.byteLength, this.port2);
+      const buffer = new Uint8Array([1, 2, 3]).buffer;
+      expect(await proxy({ b: { c: { d: buffer } } })).to.equal(3);
+      expect(buffer.byteLength).to.equal(0);
+    }
+  );
 
   it("will transfer a message port", async function() {
     const proxy = Comlink.proxy(this.port1);
@@ -424,6 +431,34 @@ describe("Comlink in the same realm", function() {
     const proxy = Comlink.proxy(this.port1, { value: {} });
     Comlink.expose({ value: 4 }, this.port2);
     expect(await proxy.value).to.equal(4);
+  });
+
+  it("can call a method on a nested object when wrapped with proxyValue()", async function() {
+    Comlink.expose(
+      {
+        prop: Comlink.proxyValue({
+          method(p) {
+            return p;
+          }
+        })
+      },
+      this.port2
+    );
+    const proxy = Comlink.proxy(this.port1);
+    expect(await proxy.prop.method(123)).to.equal(123);
+  });
+
+  it("can retrieve a property on a nested object when wrapped with proxyValue()", async function() {
+    Comlink.expose(
+      {
+        prop1: Comlink.proxyValue({
+          prop2: 123
+        })
+      },
+      this.port2
+    );
+    const proxy = Comlink.proxy(this.port1);
+    expect(await proxy.prop1.prop2).to.equal(123);
   });
 });
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["types.ts"],
+  "exclude": []
+}

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,0 +1,34 @@
+// This file contains tests that assert that the TypeScript types are correct, using $Expect* comments
+// Check them with `npm run dtslint`
+// This code is only analyzed, not executed.
+
+import * as Comlink from "../comlink";
+
+async function main() {
+  class Foo {
+    constructor(cParam: string) {}
+    prop1: string = "abc";
+    proxyProp = Comlink.proxyValue(new Bar()); // $ExpectType Bar & ProxyValue
+  }
+
+  class Bar {
+    prop2: string = "abc";
+    method(param: string): number {
+      return 123;
+    }
+  }
+
+  const proxy = Comlink.proxy<Foo>(self); // $ExpectType ProxiedObject<Foo>
+
+  proxy.prop1; // $ExpectType Promise<string>
+  proxy.proxyProp; // $ExpectType ProxiedObject<Pick<Bar & ProxyValue, "prop2" | "method">>
+  proxy.proxyProp.prop2; // $ExpectType Promise<string>
+  proxy.proxyProp.method("param"); // $ExpectType Promise<number>
+  proxy.proxyProp.method(123); // $ExpectError
+  proxy.proxyProp.method(); // $ExpectError
+
+  const ProxiedFooClass = Comlink.proxy<typeof Foo>(self);
+  await new ProxiedFooClass("test"); // $ExpectType ProxiedObject<Foo>
+  await new ProxiedFooClass(123); // $ExpectError
+  await new ProxiedFooClass(); // $ExpectError
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,5 +56,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  }
+  },
+  "exclude": ["tests/types.ts"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rulesDirectory": "./node_modules/dtslint/bin/rules",
+  "rules": {
+    "expect": true
+  }
+}


### PR DESCRIPTION
Closes #203 

This makes it so that the `Comlink.proxy()` return type does not Promisify properties that were wrapped by `Comlink.proxyValue()`.
This allows type-safe nested method calls and property accesses of proxies objects.

To accomplish this, it exposes the `proxyValue` symbol to the type system so that the `Comlink.proxy()` return type can type switch on its presence.

To prevent regressions of the types, this adds tests for the types with dtslint.

I also added two runtime unit tests that verify the runtime behaviour.