### PR TITLE
fix MessageChannelAdapter issue

### DIFF
--- a/dist/messagechanneladapter.js
+++ b/dist/messagechanneladapter.js
@@ -17,8 +17,6 @@ export function wrap(smc, id = null) {
 }
 function hookup(internalPort, smc, id = null) {
     internalPort.onmessage = (event) => {
-        if (!id)
-            id = generateUID();
         const msg = event.data;
         const messageChannels = Array.from(findMessageChannels(event.data));
         for (const messageChannel of messageChannels) {
@@ -38,6 +36,8 @@ function hookup(internalPort, smc, id = null) {
             return;
         }
         if (id && id !== data.id)
+            return;
+        if (!id && data.id)
             return;
         const mcs = data.messageChannels.map(messageChannel => {
             const id = messageChannel.reduce((obj, key) => obj[key], data.msg);

--- a/dist/umd/messagechanneladapter.js
+++ b/dist/umd/messagechanneladapter.js
@@ -18,7 +18,7 @@
     else if (typeof define === "function" && define.amd) {
         define(["require", "exports"], factory);
     }
-else {factory([], self.Comlink={});}
+else {factory([], self.MessageChannelAdapter={});}
 })(function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -30,8 +30,6 @@ else {factory([], self.Comlink={});}
     exports.wrap = wrap;
     function hookup(internalPort, smc, id = null) {
         internalPort.onmessage = (event) => {
-            if (!id)
-                id = generateUID();
             const msg = event.data;
             const messageChannels = Array.from(findMessageChannels(event.data));
             for (const messageChannel of messageChannels) {
@@ -51,6 +49,8 @@ else {factory([], self.Comlink={});}
                 return;
             }
             if (id && id !== data.id)
+                return;
+            if (!id && data.id)
                 return;
             const mcs = data.messageChannels.map(messageChannel => {
                 const id = messageChannel.reduce((obj, key) => obj[key], data.msg);

--- a/mangle_umd.js
+++ b/mangle_umd.js
@@ -1,13 +1,16 @@
 const fs = require("fs");
 
-function mangleUMD(contents) {
+function mangleUMD(contents, global) {
   const lines = contents.split("\n");
-  lines.splice(20, 0, "else {factory([], self.Comlink={});}");
+  lines.splice(20, 0, `else {factory([], self.${global}={});}`);
   return lines.join("\n");
 }
 
-["dist/umd/comlink.js", "dist/umd/messagechanneladapter.js"].forEach(file => {
+Object.entries({
+  Comlink: "dist/umd/comlink.js",
+  MessageChannelAdapter: "dist/umd/messagechanneladapter.js"
+}).forEach(([lib, file]) => {
   const contents = fs.readFileSync(file).toString();
-  const mangled = mangleUMD(contents);
+  const mangled = mangleUMD(contents, lib);
   fs.writeFileSync(file, mangled);
 });

--- a/messagechanneladapter.ts
+++ b/messagechanneladapter.ts
@@ -36,7 +36,6 @@ function hookup(
   id: string | null = null
 ): void {
   internalPort.onmessage = (event: MessageEvent) => {
-    if (!id) id = generateUID();
     const msg = event.data;
     const messageChannels = Array.from(findMessageChannels(event.data));
     for (const messageChannel of messageChannels) {
@@ -56,6 +55,7 @@ function hookup(
       return;
     }
     if (id && id !== data.id) return;
+    if (!id && data.id) return;
     const mcs = data.messageChannels.map(messageChannel => {
       const id = messageChannel.reduce((obj, key) => obj[key], data.msg);
       const port = wrap(smc, id);


### PR DESCRIPTION
- fix a MessageChannelAdapter issue that pingPongMessage failed to receive response on on top level channel if `wrap()` without an id
- update mangle_umd script to let MessageChannelAdapter exports to window.MessageChannelAdapter