### PR TITLE
Improve types for parameters of proxied functions

### DIFF
--- a/comlink.ts
+++ b/comlink.ts
@@ -16,12 +16,12 @@ export interface Endpoint {
 
   addEventListener(
     type: "message",
-    listener: (this: MessagePort, ev: MessageEvent) => any,
+    listener: (ev: MessageEvent) => any,
     options?: boolean | AddEventListenerOptions
   ): void;
   removeEventListener(
     type: "message",
-    listener: (this: MessagePort, ev: MessageEvent) => any,
+    listener: (ev: MessageEvent) => any,
     options?: boolean | AddEventListenerOptions
   ): void;
 }

--- a/comlink.ts
+++ b/comlink.ts
@@ -397,7 +397,7 @@ function windowEndpoint(w: Window): Endpoint {
   };
 }
 
-function isEndpoint(endpoint: any): endpoint is Endpoint {
+export function isEndpoint(endpoint: any): endpoint is Endpoint {
   return (
     "addEventListener" in endpoint &&
     "removeEventListener" in endpoint &&

--- a/comlink.ts
+++ b/comlink.ts
@@ -13,15 +13,16 @@
 
 export interface Endpoint {
   postMessage(message: any, transfer?: any[]): void;
+
   addEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: {}
+    type: "message",
+    listener: (this: MessagePort, ev: MessageEvent) => any,
+    options?: boolean | AddEventListenerOptions
   ): void;
   removeEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: {}
+    type: "message",
+    listener: (this: MessagePort, ev: MessageEvent) => any,
+    options?: boolean | AddEventListenerOptions
   ): void;
 }
 
@@ -386,8 +387,12 @@ function isRawWrappedValue(arg: WrappedValue): arg is RawWrappedValue {
 function windowEndpoint(w: Window): Endpoint {
   if (self.constructor.name !== "Window") throw Error("self is not a window");
   return {
-    addEventListener: self.addEventListener.bind(self),
-    removeEventListener: self.removeEventListener.bind(self),
+    addEventListener: self.addEventListener.bind(
+      self
+    ) as Endpoint["addEventListener"],
+    removeEventListener: self.removeEventListener.bind(
+      self
+    ) as Endpoint["removeEventListener"],
     postMessage: (msg, transfer) => w.postMessage(msg, "*", transfer)
   };
 }

--- a/comlink.ts
+++ b/comlink.ts
@@ -434,7 +434,10 @@ function detachMessageHandler(
 }
 
 function isMessagePort(endpoint: Endpoint): endpoint is MessagePort {
-  return endpoint.constructor.name === "MessagePort";
+  return (
+    typeof (endpoint as MessagePort).start === "function" &&
+    typeof (endpoint as MessagePort).close === "function"
+  );
 }
 
 function isWindow(endpoint: Endpoint | Window): endpoint is Window {

--- a/dist/comlink.d.ts
+++ b/dist/comlink.d.ts
@@ -14,12 +14,12 @@ export interface Endpoint {
   postMessage(message: any, transfer?: any[]): void;
   addEventListener(
     type: "message",
-    listener: (this: MessagePort, ev: MessageEvent) => any,
+    listener: (ev: MessageEvent) => any,
     options?: boolean | AddEventListenerOptions
   ): void;
   removeEventListener(
     type: "message",
-    listener: (this: MessagePort, ev: MessageEvent) => any,
+    listener: (ev: MessageEvent) => any,
     options?: boolean | AddEventListenerOptions
   ): void;
 }

--- a/dist/comlink.d.ts
+++ b/dist/comlink.d.ts
@@ -13,14 +13,14 @@
 export interface Endpoint {
   postMessage(message: any, transfer?: any[]): void;
   addEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: {}
+    type: "message",
+    listener: (this: MessagePort, ev: MessageEvent) => any,
+    options?: boolean | AddEventListenerOptions
   ): void;
   removeEventListener(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: {}
+    type: "message",
+    listener: (this: MessagePort, ev: MessageEvent) => any,
+    options?: boolean | AddEventListenerOptions
   ): void;
 }
 declare type Promisify<T> = T extends Promise<any> ? T : Promise<T>;

--- a/dist/comlink.d.ts
+++ b/dist/comlink.d.ts
@@ -80,4 +80,5 @@ export declare function expose(
   rootObj: Exposable,
   endpoint: Endpoint | Window
 ): void;
+export declare function isEndpoint(endpoint: any): endpoint is Endpoint;
 export {};

--- a/dist/comlink.js
+++ b/dist/comlink.js
@@ -219,7 +219,8 @@ function detachMessageHandler(endpoint, f) {
     endpoint.removeEventListener("message", f);
 }
 function isMessagePort(endpoint) {
-    return endpoint.constructor.name === "MessagePort";
+    return (typeof endpoint.start === "function" &&
+        typeof endpoint.close === "function");
 }
 function isWindow(endpoint) {
     // TODO: This doesn’t work on cross-origin iframes.

--- a/dist/comlink.js
+++ b/dist/comlink.js
@@ -193,7 +193,7 @@ function windowEndpoint(w) {
         postMessage: (msg, transfer) => w.postMessage(msg, "*", transfer)
     };
 }
-function isEndpoint(endpoint) {
+export function isEndpoint(endpoint) {
     return ("addEventListener" in endpoint &&
         "removeEventListener" in endpoint &&
         "postMessage" in endpoint);

--- a/dist/messagechanneladapter.d.ts
+++ b/dist/messagechanneladapter.d.ts
@@ -10,7 +10,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface StringMessageChannel extends EventTarget {
+import { Endpoint } from "./comlink";
+export interface StringMessageChannel
+  extends Pick<Endpoint, "addEventListener" | "removeEventListener"> {
   send(data: string): void;
 }
 export declare function wrap(

--- a/dist/umd/comlink.d.ts
+++ b/dist/umd/comlink.d.ts
@@ -12,8 +12,8 @@
  */
 export interface Endpoint {
     postMessage(message: any, transfer?: any[]): void;
-    addEventListener(type: "message", listener: (this: MessagePort, ev: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener(type: "message", listener: (this: MessagePort, ev: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: "message", listener: (ev: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(type: "message", listener: (ev: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
 }
 declare type Promisify<T> = Promise<Unpromisify<T>>;
 declare type Unpromisify<P> = P extends Promise<infer T> ? T : P;

--- a/dist/umd/comlink.d.ts
+++ b/dist/umd/comlink.d.ts
@@ -56,4 +56,5 @@ export declare const transferHandlers: Map<string, TransferHandler>;
 export declare function proxy<T = any>(endpoint: Endpoint | Window, target?: any): ProxyResult<T>;
 export declare function proxyValue<T>(obj: T): T & ProxyValue;
 export declare function expose(rootObj: Exposable, endpoint: Endpoint | Window): void;
+export declare function isEndpoint(endpoint: any): endpoint is Endpoint;
 export {};

--- a/dist/umd/comlink.d.ts
+++ b/dist/umd/comlink.d.ts
@@ -12,8 +12,8 @@
  */
 export interface Endpoint {
     postMessage(message: any, transfer?: any[]): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: {}): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: {}): void;
+    addEventListener(type: "message", listener: (this: MessagePort, ev: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(type: "message", listener: (this: MessagePort, ev: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
 }
 declare type Promisify<T> = T extends Promise<any> ? T : Promise<T>;
 /**

--- a/dist/umd/comlink.d.ts
+++ b/dist/umd/comlink.d.ts
@@ -15,7 +15,8 @@ export interface Endpoint {
     addEventListener(type: "message", listener: (this: MessagePort, ev: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
     removeEventListener(type: "message", listener: (this: MessagePort, ev: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
 }
-declare type Promisify<T> = T extends Promise<any> ? T : Promise<T>;
+declare type Promisify<T> = Promise<Unpromisify<T>>;
+declare type Unpromisify<P> = P extends Promise<infer T> ? T : P;
 /**
  * Symbol that gets added to objects by `Comlink.proxy()`.
  */
@@ -26,24 +27,46 @@ export declare const proxyValueSymbol: unique symbol;
 export interface ProxyValue {
     [proxyValueSymbol]: true;
 }
-/** Helper that omits all keys K from object T */
-declare type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+declare type ProxyProperty<T> = T extends Function | ProxyValue ? ProxyResult<T> : Promisify<T>;
+declare type UnproxyProperty<T> = T extends Function | ProxyValue ? ProxyInput<T> : Unpromisify<T>;
 /**
  * `ProxiedObject<T>` is equivalent to `T`, except that all properties are now promises and
  * all functions now return promises, except if they were wrapped with `Comlink.proxyValue()`.
  * It effectively async-ifies an object.
  */
-declare type ProxiedObject<T> = {
-    [P in keyof T]: T[P] extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promisify<R> : (T[P] extends ProxyValue ? ProxiedObject<Omit<T[P], keyof ProxyValue>> : Promisify<T[P]>);
+export declare type ProxiedObject<T> = {
+    [P in keyof T]: ProxyProperty<T[P]>;
 };
 /**
- * ProxyResult<T> is an augmentation of ProxyObject<T> that also handles raw functions
+ * Inverse of `ProxiedObject<T>`
+ */
+export declare type UnwrapProxiedObject<T> = {
+    [P in keyof T]: UnproxyProperty<T[P]>;
+};
+/**
+ * Proxies `T` if it is a ProxyValue, clones it otherwise.
+ */
+export declare type ProxyOrClone<T> = T extends ProxyValue ? ProxyResult<T> : T;
+export declare type UnproxyOrClone<T> = T extends ProxiedObject<ProxyValue> ? ProxyInput<T> : T;
+/**
+ * The inverse of `ProxyResult<T>`.
+ * Takes a `ProxyResult<T>` and returns its original input `T`.
+ */
+export declare type ProxyInput<R> = UnwrapProxiedObject<R> & (R extends (...args: infer Arguments) => infer R ? (...args: {
+    [I in keyof Arguments]: ProxyOrClone<Arguments[I]>;
+}) => UnproxyOrClone<Unpromisify<R>> | Promise<UnproxyOrClone<Unpromisify<R>>> : unknown);
+/**
+ * `ProxyResult<T>` is an augmentation of `ProxyObject<T>` that also handles raw functions
  * and classes correctly.
  */
-export declare type ProxyResult<T> = ProxiedObject<T> & (T extends (...args: infer Arguments) => infer R ? (...args: Arguments) => Promisify<R> : unknown) & (T extends {
+export declare type ProxyResult<T> = ProxiedObject<T> & (T extends (...args: infer Arguments) => infer R ? (...args: {
+    [I in keyof Arguments]: UnproxyOrClone<Arguments[I]>;
+}) => Promisify<ProxyOrClone<R>> : unknown) & (T extends {
     new (...args: infer ArgumentsType): infer InstanceType;
 } ? {
-    new (...args: ArgumentsType): Promisify<ProxiedObject<InstanceType>>;
+    new (...args: {
+        [I in keyof ArgumentsType]: UnproxyOrClone<ArgumentsType[I]>;
+    }): Promisify<ProxiedObject<InstanceType>>;
 } : unknown);
 export declare type Proxy = Function;
 export declare type Exposable = Function | Object;

--- a/dist/umd/comlink.js
+++ b/dist/umd/comlink.js
@@ -213,6 +213,7 @@ else {factory([], self.Comlink={});}
             "removeEventListener" in endpoint &&
             "postMessage" in endpoint);
     }
+    exports.isEndpoint = isEndpoint;
     function activateEndpoint(endpoint) {
         if (isMessagePort(endpoint))
             endpoint.start();

--- a/dist/umd/comlink.js
+++ b/dist/umd/comlink.js
@@ -234,7 +234,8 @@ else {factory([], self.Comlink={});}
         endpoint.removeEventListener("message", f);
     }
     function isMessagePort(endpoint) {
-        return endpoint.constructor.name === "MessagePort";
+        return (typeof endpoint.start === "function" &&
+            typeof endpoint.close === "function");
     }
     function isWindow(endpoint) {
         // TODO: This doesn’t work on cross-origin iframes.

--- a/dist/umd/messagechanneladapter.d.ts
+++ b/dist/umd/messagechanneladapter.d.ts
@@ -10,7 +10,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface StringMessageChannel extends EventTarget {
+import { Endpoint } from './comlink';
+export interface StringMessageChannel extends Pick<Endpoint, 'addEventListener' | 'removeEventListener'> {
     send(data: string): void;
 }
 export declare function wrap(smc: StringMessageChannel, id?: string | null): MessagePort;

--- a/messagechanneladapter.ts
+++ b/messagechanneladapter.ts
@@ -11,7 +11,9 @@
  * limitations under the License.
  */
 
-export interface StringMessageChannel extends EventTarget {
+import { Endpoint } from './comlink'
+
+export interface StringMessageChannel extends Pick<Endpoint, 'addEventListener' | 'removeEventListener'> {
   send(data: string): void;
 }
 

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -5,30 +5,153 @@
 import * as Comlink from "../comlink";
 
 async function main() {
+  interface Baz {
+    baz: number;
+    method(): number;
+  }
+
   class Foo {
     constructor(cParam: string) {}
     prop1: string = "abc";
     proxyProp = Comlink.proxyValue(new Bar()); // $ExpectType Bar & ProxyValue
+    methodWithTupleParams(...args: [string] | [number, string]): number {
+      return 123;
+    }
+    methodWithProxiedReturnValue(): Baz & Comlink.ProxyValue {
+      return Comlink.proxyValue({ baz: 123, method: () => 123 });
+    }
+    methodWithProxyParameter(param: Baz & Comlink.ProxyValue): void {}
   }
 
   class Bar {
-    prop2: string = "abc";
+    prop2: string | number = "abc";
     method(param: string): number {
       return 123;
+    }
+    methodWithProxiedReturnValue(): Baz & Comlink.ProxyValue {
+      return Comlink.proxyValue({ baz: 123, method: () => 123 });
     }
   }
 
   const proxy = Comlink.proxy<Foo>(self); // $ExpectType ProxiedObject<Foo>
 
   proxy.prop1; // $ExpectType Promise<string>
-  proxy.proxyProp; // $ExpectType ProxiedObject<Pick<Bar & ProxyValue, "prop2" | "method">>
-  proxy.proxyProp.prop2; // $ExpectType Promise<string>
+  proxy.methodWithTupleParams(123, "abc"); // $ExpectType Promise<number>
+  proxy.methodWithTupleParams("abc"); // $ExpectType Promise<number>
+  proxy.proxyProp; // $ExpectType ProxiedObject<Bar & ProxyValue>
+  proxy.proxyProp.prop2; // $ExpectType Promise<string> | Promise<number>
   proxy.proxyProp.method("param"); // $ExpectType Promise<number>
   proxy.proxyProp.method(123); // $ExpectError
   proxy.proxyProp.method(); // $ExpectError
+  proxy.methodWithProxiedReturnValue(); // $ExpectType Promise<ProxiedObject<Baz & ProxyValue>>
+  proxy.proxyProp.methodWithProxiedReturnValue(); // $ExpectType Promise<ProxiedObject<Baz & ProxyValue>>
+  (await proxy.methodWithProxiedReturnValue()).baz; // $ExpectType Promise<number>
+  (await proxy.methodWithProxiedReturnValue()).method(); // $ExpectType Promise<number>
 
   const ProxiedFooClass = Comlink.proxy<typeof Foo>(self);
   await new ProxiedFooClass("test"); // $ExpectType ProxiedObject<Foo>
   await new ProxiedFooClass(123); // $ExpectError
   await new ProxiedFooClass(); // $ExpectError
+
+  //
+  // Tests for advanced proxy use cases
+  //
+
+  interface Subscriber<T> {
+    closed: boolean;
+    next: (value: T) => void;
+  }
+  interface Unsubscribable {
+    unsubscribe(): void;
+  }
+  /** A Subscribable that can get proxied by Comlink */
+  interface ProxySubscribable<T> extends Comlink.ProxyValue {
+    subscribe(
+      subscriber: Comlink.ProxyResult<
+        Partial<Subscriber<T>> & Comlink.ProxyValue
+      >
+    ): Unsubscribable & Comlink.ProxyValue;
+  }
+
+  /** Simple parameter object that gets cloned (not proxied) */
+  interface Params {
+    textDocument: string;
+  }
+
+  class Registry {
+    async registerProvider(
+      provider: Comlink.ProxyResult<
+        ((params: Params) => ProxySubscribable<string>) & Comlink.ProxyValue
+      >
+    ) {
+      // $ExpectType Promise<ProxiedObject<ProxySubscribable<string>>>
+      const resultPromise = provider({ textDocument: "foo" });
+      const result = await resultPromise;
+
+      // $ExpectType Promise<ProxiedObject<Unsubscribable & ProxyValue>>
+      const subscriptionPromise = result.subscribe({
+        [Comlink.proxyValueSymbol]: true,
+        next: value => {
+          value; // $ExpectType string
+        }
+      });
+      const subscriber = Comlink.proxyValue({
+        next: (value: string) => console.log(value)
+      });
+      result.subscribe(subscriber);
+
+      (await subscriptionPromise).unsubscribe(); // $ExpectType Promise<void>
+    }
+  }
+  const proxy2 = Comlink.proxy<Registry>(self);
+
+  proxy2.registerProvider(
+    // Synchronous callback
+    Comlink.proxyValue(({ textDocument }: Params) => {
+      return Comlink.proxyValue({
+        subscribe(
+          subscriber: Comlink.ProxyResult<
+            Partial<Subscriber<string>> & Comlink.ProxyValue
+          >
+        ): Unsubscribable & Comlink.ProxyValue {
+          // Important to test here is that union types (as Function | undefined) distribute properly
+          // when wrapped in Promises/proxied
+
+          subscriber.closed; // $ExpectType Promise<true> | Promise<undefined> | Promise<false> | undefined
+          subscriber.next; // $ExpectType Promise<undefined> | ProxyResult<(value: string) => void> | undefined
+          subscriber.next(); // $ExpectError
+
+          if (subscriber.next) {
+            // Only checking for presence is not enough, since it could be a Promise
+            subscriber.next(); // $ExpectError
+          }
+
+          if (typeof subscriber.next === "function") {
+            subscriber.next("abc");
+          }
+
+          return Comlink.proxyValue({ unsubscribe() {} });
+        }
+      });
+    })
+  );
+  proxy2.registerProvider(
+    // Async callback
+    Comlink.proxyValue(async ({ textDocument }: Params) => {
+      return Comlink.proxyValue({
+        subscribe(
+          subscriber: Comlink.ProxyResult<
+            Partial<Subscriber<string>> & Comlink.ProxyValue
+          >
+        ): Unsubscribable & Comlink.ProxyValue {
+          subscriber.next; // $ExpectType Promise<undefined> | ProxyResult<(value: string) => void> | undefined
+          // Only checking for presence is not enough, since it could be a Promise
+          if (typeof subscriber.next === "function") {
+            subscriber.next("abc");
+          }
+          return Comlink.proxyValue({ unsubscribe() {} });
+        }
+      });
+    })
+  );
 }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -3,8 +3,16 @@
 // This code is only analyzed, not executed.
 
 import * as Comlink from "../comlink";
+import { wrap } from "../messagechanneladapter";
 
 async function main() {
+  Comlink.proxy(new MessageChannel().port1);
+  Comlink.expose({}, new MessageChannel().port2);
+  const connection = new RTCPeerConnection();
+  const channel = connection.createDataChannel("comlink");
+  Comlink.proxy(wrap(channel));
+  Comlink.expose({}, wrap(channel));
+
   interface Baz {
     baz: number;
     method(): number;


### PR DESCRIPTION
Parameters of proxied functions need to have the reverse transformation of results applied, since users provide raw/marked values while the other side receives proxies.

Includes tests.