### PR TITLE
Detect TypedArray.buffer is Transferable

### DIFF
--- a/comlink.ts
+++ b/comlink.ts
@@ -526,7 +526,10 @@ function* iterateAllProperties(
   if (visited.has(value)) return;
   if (typeof value === "string") return;
   if (typeof value === "object") visited.add(value);
-  if (ArrayBuffer.isView(value)) return;
+  if (ArrayBuffer.isView(value)) {
+    yield { value: value.buffer, path: [...path, 'buffer'] };
+    return;
+  }
   yield { value, path };
 
   const keys = Object.keys(value);

--- a/dist/comlink.js
+++ b/dist/comlink.js
@@ -303,8 +303,10 @@ function* iterateAllProperties(value, path = [], visited = null) {
         return;
     if (typeof value === "object")
         visited.add(value);
-    if (ArrayBuffer.isView(value))
+    if (ArrayBuffer.isView(value)) {
+        yield { value: value.buffer, path: [...path, 'buffer'] };
         return;
+    }
     yield { value, path };
     const keys = Object.keys(value);
     for (const key of keys)

--- a/dist/umd/comlink.js
+++ b/dist/umd/comlink.js
@@ -318,8 +318,10 @@ else {factory([], self.Comlink={});}
             return;
         if (typeof value === "object")
             visited.add(value);
-        if (ArrayBuffer.isView(value))
+        if (ArrayBuffer.isView(value)) {
+            yield { value: value.buffer, path: [...path, 'buffer'] };
             return;
+        }
         yield { value, path };
         const keys = Object.keys(value);
         for (const key of keys)

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -300,6 +300,17 @@ describe("Comlink in the same realm", function() {
     }
   );
 
+  guardedIt(isNotSafari11_1)(
+    "will transfer buffers in typedarray",
+    async function() {
+      const proxy = Comlink.proxy(this.port1);
+      Comlink.expose(b => b.buffer.byteLength, this.port2);
+      const typedarray = new Uint8Array([1, 2, 3]);
+      expect(await proxy(typedarray)).to.equal(3);
+      expect(typedarray.buffer.byteLength).to.equal(0);
+    }
+  );
+
   it("will transfer a message port", async function() {
     const proxy = Comlink.proxy(this.port1);
     Comlink.expose(a => a.postMessage("ohai"), this.port2);


### PR DESCRIPTION
TypedArray.prototype.buffer is ArrayBuffer, so it is Transferable.
However, because of `iterateAllProperties` skips TypedArray, TypedArray.prototype.buffer won't be detected as Transferable.

This PR enable to detect Transferable in TypedArray.