### PR TITLE
Fix typo

### DIFF
--- a/structured-clone-table.md
+++ b/structured-clone-table.md
@@ -1,6 +1,6 @@
 # Behavior of [Structured Clone]
 
-[Structured clone] is JavaScript’s algorithm to create “deep copies” of values. It is used for `postMessage()` and therefore is used extensively under the hood with Comlink. By default, every function paramter and function return value is structured cloned. Here is a table of how the structured clone algorithm handles different kinds of values. Or to phrase it differently: If you pass a value from the left side as a paramter into a proxy’d function, the actual function code will get what is listed on the right side.
+[Structured clone] is JavaScript’s algorithm to create “deep copies” of values. It is used for `postMessage()` and therefore is used extensively under the hood with Comlink. By default, every function parameter and function return value is structured cloned. Here is a table of how the structured clone algorithm handles different kinds of values. Or to phrase it differently: If you pass a value from the left side as a parameter into a proxy’d function, the actual function code will get what is listed on the right side.
 
 | Input                      |     Output     | Notes                                                                                        |
 | -------------------------- | :------------: | -------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
There was a typo in the word "parameter". Instead of parameter it was written paramter.