### PR TITLE
fix(createproxy): allow proxy under non-eval csp

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -160,7 +160,7 @@ function createProxy<T>(
   ep: Endpoint,
   path: (string | number | symbol)[] = []
 ): Remote<T> {
-  const proxy: Function = new Proxy(new Function(), {
+  const proxy: Function = new Proxy(function() {}, {
     get(_target, prop) {
       if (prop === "then") {
         if (path.length === 0) {


### PR DESCRIPTION
### Description

I think this is fix to somewhat specific usecases, but hope this is not hurting general environments but also fixes my problem.

In our application we use comlink to communicate between the different context in Electron (https://electronjs.org/), specifically for now being used between `preload` script to actual web page we load into BrowserWindow. Since we inject script in preload it does not have url for endpoint while our endpoint have CSP policy to prevent execution of script via `eval` or similar way - and using `new Function()` violates those rules.

![image](https://user-images.githubusercontent.com/1210596/57274811-442d6b80-7051-11e9-99d4-c276bda97867.png)

And effectively blocks to create new proxy object in preload context we created. 

This PR replaces creation of function in non-eval way to allow preload script can run under specific CSP policy.