### PR TITLE
Use Transferable type

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -12,7 +12,7 @@
  */
 
 export interface Endpoint {
-  postMessage(message: any, transfer?: any[]): void;
+  postMessage(message: any, transfer?: Transferable[]): void;
   addEventListener(
     type: string,
     listener: EventListenerOrEventListenerObject,


### PR DESCRIPTION
TypeScript comes with a [built-in type definition](https://github.com/microsoft/TypeScript/blob/v3.4.5/lib/lib.dom.d.ts#L18304) for [transferable objects](https://developer.mozilla.org/en-US/docs/Web/API/Transferable). Let's use it! 🙂

This changes the following types in Comlink's public API (`dist/umd/comlink.d.ts`):
```diff
 export interface TransferHandler {
     canHandle(obj: any): boolean;
-    serialize(obj: any): [any, any[]];
+    serialize(obj: any): [any, Transferable[]];
     deserialize(obj: any): any;
 }
-export declare function transfer(obj: any, transfers: any[]): any;
+export declare function transfer(obj: any, transfers: Transferable[]): any;
```