### PR TITLE
fix: replace Window type with reduced types

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -13,11 +13,12 @@
 
 import {
   Endpoint,
+  EventSource,
   Message,
   MessageType,
+  PostMessageWithOrigin,
   WireValue,
-  WireValueType,
-  WindowLike
+  WireValueType
 } from "./protocol.js";
 export { Endpoint };
 
@@ -247,8 +248,8 @@ export function proxy<T>(obj: T): T & { [proxyMarker]: true } {
 }
 
 export function windowEndpoint(
-  w: WindowLike,
-  context: WindowLike = self
+  w: PostMessageWithOrigin,
+  context: EventSource = self
 ): Endpoint {
   return {
     postMessage: (msg: any, transferables: Transferable[]) =>

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -16,7 +16,8 @@ import {
   Message,
   MessageType,
   WireValue,
-  WireValueType
+  WireValueType,
+  WindowLike
 } from "./protocol.js";
 export { Endpoint };
 
@@ -245,7 +246,10 @@ export function proxy<T>(obj: T): T & { [proxyMarker]: true } {
   return Object.assign(obj, { [proxyMarker]: true }) as any;
 }
 
-export function windowEndpoint(w: Window, context = self): Endpoint {
+export function windowEndpoint(
+  w: WindowLike,
+  context: WindowLike = self
+): Endpoint {
   return {
     postMessage: (msg: any, transferables: Transferable[]) =>
       w.postMessage(msg, "*", transferables),

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -11,8 +11,7 @@
  * limitations under the License.
  */
 
-export interface Endpoint {
-  postMessage(message: any, transfer?: Transferable[]): void;
+export interface EventSource {
   addEventListener(
     type: string,
     listener: EventListenerOrEventListenerObject,
@@ -23,6 +22,18 @@ export interface Endpoint {
     listener: EventListenerOrEventListenerObject,
     options?: {}
   ): void;
+}
+
+export interface WindowLike extends EventSource {
+  postMessage(
+    message: any,
+    targetOrigin: string,
+    transfer?: Transferable[]
+  ): void;
+}
+
+export interface Endpoint extends EventSource {
+  postMessage(message: any, transfer?: Transferable[]): void;
   start?: () => void;
 }
 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -24,7 +24,7 @@ export interface EventSource {
   ): void;
 }
 
-export interface WindowLike extends EventSource {
+export interface PostMessageWithOrigin {
   postMessage(
     message: any,
     targetOrigin: string,


### PR DESCRIPTION
If comlink is used with typescript, where only compilerOptions.lib "webworker" without "dom"
is configured, the error "Cannot find name 'Window'" is thrown. This PR replaces the Window
type with a custom types that declare the minimal required functionality to work.