### PR TITLE
Temp memory leak fix

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -46,7 +46,7 @@ export type Remote<T> =
     T extends { new (...args: infer R1): infer R2 }
       ? { new (...args: R1): Promise<Remote<R2>> }
       : unknown
-  )
+  );
 
 export interface TransferHandler {
   canHandle(obj: any): boolean;

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -66,7 +66,8 @@ export const enum MessageType {
   SET,
   APPLY,
   CONSTRUCT,
-  ENDPOINT
+  ENDPOINT,
+  RELEASE
 }
 
 export interface GetMessage {
@@ -101,9 +102,16 @@ export interface EndpointMessage {
   type: MessageType.ENDPOINT;
 }
 
+export interface ReleaseMessage {
+  id?: MessageID;
+  type: MessageType.RELEASE;
+  path: string[];
+}
+
 export type Message =
   | GetMessage
   | SetMessage
   | ApplyMessage
   | ConstructMessage
-  | EndpointMessage;
+  | EndpointMessage
+  | ReleaseMessage;

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -496,6 +496,14 @@ describe("Comlink in the same realm", function() {
     expect(await otherProxy.c()).to.equal(5);
     expect(await proxy.c()).to.equal(5);
   });
+
+  it("released proxy should no longer be useable and throw an exception", async function() {
+    const thing = Comlink.wrap(this.port1);
+    Comlink.expose(SampleClass, this.port2);
+    const instance = await new thing();
+    await instance.releaseProxy();
+    expect(() => instance.method()).to.throw();
+  });
 });
 
 function guardedIt(f) {

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -501,7 +501,7 @@ describe("Comlink in the same realm", function() {
     const thing = Comlink.wrap(this.port1);
     Comlink.expose(SampleClass, this.port2);
     const instance = await new thing();
-    await instance.releaseProxy();
+    await instance[Comlink.releaseProxy]();
     expect(() => instance.method()).to.throw();
   });
 });


### PR DESCRIPTION
This PR provides a fix for memory leak discussed in https://github.com/GoogleChromeLabs/comlink/issues/63

The fix here provides a method 'releaseProxy' on the object return by createProxy. This allows the consumer of the proxy to indicate when they are done using the proxy and free up held refs and close the message ports on both ends. If proxy is subsequently used an exception will be thrown.

As discussed with @surma this PR provides a temporary fix until WeakRefs are widely supported, then comlink will be able to properly address issue and this PR will be obsolete.

To use with leaking test in issue #63 the test function in app.ts would be changed to:

```
async function test()
{
    const app = await new App();
    const returned = await app.getObject();
    await returned.work();
    // stop memory leaks - release data - we're done!
    await returned.releaseProxy();
    await app.releaseProxy();
}
```