### PR TITLE
fix: add support for legacy browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "comlink",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Comlink makes WebWorkers enjoyable",
   "main": "dist/umd/comlink.js",
   "module": "dist/esm/comlink.mjs",
+  "browser": "dist/umd/comlink.es3.min.js",
   "types": "dist/umd/comlink.d.ts",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
Relatively easy and unobtrusive fix for supporting older browsers by removing async await and spread operators. 