### PR TITLE
Fix custom error fields serialization

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -79,6 +79,7 @@ export const transferHandlers = new Map<string, TransferHandler>([
         let serialized = obj;
         if (isError) {
           serialized = {
+            ...obj,
             isError,
             message: obj.message,
             stack: obj.stack

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -116,6 +116,27 @@ describe("Comlink in the same realm", function() {
     }
   });
 
+  it("can throw customized error object with an additional params", async function() {
+    const thing = Comlink.wrap(this.port1);
+    Comlink.expose(_ => {
+      class CustomError extends Error {
+        customField = null;
+        constructor (message, customField) {
+          super(message);
+          this.customField = customField;
+          Object.setPrototypeOf(this, CustomError.prototype);
+        }
+      }
+      throw new CustomError("Some error message", "custom field test");
+    }, this.port2);
+    try {
+      await thing();
+    } catch (err) {
+      expect(err.message).to.equal("Some error message");
+      expect(err.customField).to.equal("custom field test");
+    }
+  });
+
   it("can forward an async function error", async function() {
     const thing = Comlink.wrap(this.port1);
     Comlink.expose({


### PR DESCRIPTION
Hi @surma ! First of all I want to thank you for comlink! It's very helpful. I found an error that bugs me out.

In my project I use custom class that extends Error class. But when it gets serialized my custom fields getting dropped.

```javascript
class CustomError extends Error {
  customField = null;
  constructor (message, customField) {
    super(message);
    this.customField = customField;
    Object.setPrototypeOf(this, CustomError.prototype);
  }
}
throw new CustomError("Some error message", "custom field test");
```

On the main thread `customField` is lost