### PR TITLE
Expose target to make comlink compatible  with proxy-polyfill

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -178,8 +178,8 @@ function closeEndPoint(endpoint: Endpoint) {
   if (isMessagePort(endpoint)) endpoint.close();
 }
 
-export function wrap<T>(ep: Endpoint): Remote<T> {
-  return createProxy<T>(ep) as any;
+export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
+  return createProxy<T>(ep, [], target) as any;
 }
 
 function throwIfProxyReleased(isReleased: boolean) {
@@ -190,10 +190,11 @@ function throwIfProxyReleased(isReleased: boolean) {
 
 function createProxy<T>(
   ep: Endpoint,
-  path: (string | number | symbol)[] = []
+  path: (string | number | symbol)[] = [],
+  target: object = function() {}
 ): Remote<T> {
   let isProxyReleased = false;
-  const proxy = new Proxy(function() {}, {
+  const proxy = new Proxy(target, {
     get(_target, prop) {
       throwIfProxyReleased(isProxyReleased);
       if (prop === releaseProxy) {

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -518,6 +518,12 @@ describe("Comlink in the same realm", function() {
     await instance[Comlink.releaseProxy]();
     expect(() => instance.method()).to.throw();
   });
+
+  it('can proxy with a given target', async function() {
+    const thing = Comlink.wrap(this.port1, { value: {} });
+    Comlink.expose({ value: 4 }, this.port2);
+    expect(await thing.value).to.equal(4);
+  });
 });
 
 function guardedIt(f) {


### PR DESCRIPTION
Hi there,

Right now comlink doesn't work with proxy-polyfill. This is because **proxy-polyfill** seals the object when creates the proxy and properties can't be added afterwards and **comlink** wrap function always creates the Proxy with an empty function as target.

I've checked project history and this was once addressed ( in this PR 
 https://github.com/GoogleChromeLabs/comlink/pull/113/files ) but somehow changes were lost after a big update. 

It's a very little change, Do you think is possible to add it again? I have tested using comlink with proxy-polyfills on IE11 and it just works :)

PS. I'm not very familiar with TS, let me know if I missed something.

Thanks!