### PR TITLE
Fix module not found error when using transpileOnly (#398)

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -19,7 +19,7 @@ import {
   PostMessageWithOrigin,
   WireValue,
   WireValueType
-} from "./protocol.js";
+} from "./protocol";
 export { Endpoint };
 
 export const proxyMarker = Symbol("Comlink.proxy");

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { Endpoint } from "./protocol.js";
+import { Endpoint } from "./protocol";
 
 export interface NodeEndpoint {
   postMessage(message: any, transfer?: any[]): void;


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/comlink/issues/398
Just removed `.js` extension from imports