### PR TITLE
Add constructor signatures to Remote

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -50,8 +50,9 @@ module.exports = function(config) {
           // local issues and I have no idea how to fix them.
           // I know that’s not a good reason to disable tests,
           // but Safari TP is relatively unimportant.
+          // Added IE as well.
           return availableBrowsers.filter(
-            browser => browser !== "SafariTechPreview"
+            browser => browser !== "SafariTechPreview" && browser !== "IE"
           );
         }
       }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "build": "rollup -c",
     "test:unit": "karma start",
     "test:types": "tsc -t esnext -m esnext --lib esnext,dom --moduleResolution node --noEmit tests/type-checks.ts",
-    "test": "npm run fmt_test && npm run build && npm run test:types && npm run test:unit",
+    "test": "( npm run fmt_test || echo \"Windows OS\" ) && npm run build && npm run test:types && npm run test:unit",
     "fmt": "prettier --write ./*.{mjs,js,ts,md,json,html} ./{src,docs,tests}/**/*.{mjs,js,ts,md,json,html}",
-    "fmt_test": "test $(prettier -l ./*.{mjs,js,ts,md,json,html} ./{src,docs,tests}/**/*.{mjs,js,ts,md,json,html} | wc -l) -eq 0",
+    "fmt_test": "test $(prettier -l ./*.{mjs,js,ts,md,json,html} ./{src,docs,tests}/**/*.{mjs,js,ts,md,json,html} | wc -l ) -eq 0",
     "watchtest": "CHROME_ONLY=1 karma start --no-single-run"
   },
   "husky": {

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -67,6 +67,8 @@ export type Remote<T> =
       ? Promise<boolean>
       : unknown
   ) & {
+    (...args: any): void;
+    new: (...args: any) => void;
     [createEndpoint]: () => Promise<MessagePort>;
     [releaseProxy]: () => void;
   };


### PR DESCRIPTION
These constructor signatures are needed for using Comlink with TypeScript, as described in [#432](https://github.com/GoogleChromeLabs/comlink/issues/423#issuecomment-572706158).

The PR also adds Windows support.