### PR TITLE
Fix TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rollup": "1.27.8",
     "rollup-plugin-terser": "5.1.2",
     "rollup-plugin-typescript2": "0.25.3",
-    "typescript": "3.9.0-beta"
+    "typescript": "^3.8.3"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rollup": "1.27.8",
     "rollup-plugin-terser": "5.1.2",
     "rollup-plugin-typescript2": "0.25.3",
-    "typescript": "^3.8.3"
+    "typescript": "3.8.3"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "rollup -c",
     "test:unit": "karma start",
-    "test:types": "tsc -t esnext -m esnext --lib esnext,dom --moduleResolution node --noEmit tests/type-checks.ts",
+    "test:types": "tsc -p ./tests/tsconfig.json",
+    "test:types:watch": "npm run test:types -- --watch",
     "test": "npm run fmt_test && npm run build && npm run test:types && npm run test:unit",
     "fmt": "prettier --write ./*.{mjs,js,ts,md,json,html} ./{src,docs,tests}/{,**/}*.{mjs,js,ts,md,json,html}",
     "fmt_test": "test $(prettier -l ./*.{mjs,js,ts,md,json,html} ./{src,docs,tests}/{**/,}*.{mjs,js,ts,md,json,html} | wc -l) -eq 0",
@@ -46,7 +47,7 @@
     "rollup": "1.27.8",
     "rollup-plugin-terser": "5.1.2",
     "rollup-plugin-typescript2": "0.25.3",
-    "typescript": "3.7.3"
+    "typescript": "3.9.0-beta"
   },
   "dependencies": {}
 }

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -136,7 +136,7 @@ export type Remote<T> =
             ...args: {
               [I in keyof TArguments]: UnproxyOrClone<TArguments[I]>;
             }
-          ): Promisify<RemoteObject<TInstance>>;
+          ): Promisify<Remote<TInstance>>;
         }
       : unknown) &
     // Include additional special comlink methods available on the proxy.

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -27,53 +27,154 @@ export const createEndpoint = Symbol("Comlink.endpoint");
 export const releaseProxy = Symbol("Comlink.releaseProxy");
 const throwSet = new WeakSet();
 
-// prettier-ignore
-type Promisify<T> =
-  T extends { [proxyMarker]: boolean }
-    ? Promise<Remote<T>>
-    : T extends (...args: infer R1) => infer R2
-        ? (...args: R1) => Promisify<R2>
-        : Promise<T>;
+/**
+ * Interface of values that were marked to be proxied with `comlink.proxy()`.
+ * Can also be implemented by classes.
+ */
+export interface ProxyMarked {
+  [proxyMarker]: true;
+}
 
-// prettier-ignore
+/**
+ * Takes a type and wraps it in a Promise, if it not already is one.
+ * This is to avoid `Promise<Promise<T>>`.
+ *
+ * This is the inverse of `Unpromisify<T>`.
+ */
+type Promisify<T> = T extends Promise<unknown> ? T : Promise<T>;
+/**
+ * Takes a type that may be Promise and unwraps the Promise type.
+ * If `P` is not a Promise, it returns `P`.
+ *
+ * This is the inverse of `Promisify<T>`.
+ */
+type Unpromisify<P> = P extends Promise<infer T> ? T : P;
+
+/**
+ * Takes the raw type of a remote property and returns the type that is visible to the local thread on the proxy.
+ *
+ * Note: This needs to be its own type alias, otherwise it will not distribute over unions.
+ * See https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types
+ */
+type RemoteProperty<T> =
+  // If the value is a method, comlink will proxy it automatically.
+  // Objects are only proxied if they are marked to be proxied.
+  // Otherwise, the property is converted to a Promise that resolves the cloned value.
+  T extends Function | ProxyMarked ? Remote<T> : Promisify<T>;
+
+/**
+ * Takes the raw type of a property as a remote thread would see it through a proxy (e.g. when passed in as a function
+ * argument) and returns the type that the local thread has to supply.
+ *
+ * This is the inverse of `RemoteProperty<T>`.
+ *
+ * Note: This needs to be its own type alias, otherwise it will not distribute over unions. See
+ * https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types
+ */
+type LocalProperty<T> = T extends Function | ProxyMarked
+  ? Local<T>
+  : Unpromisify<T>;
+
+/**
+ * Proxies `T` if it is a `ProxyMarked`, clones it otherwise (as handled by structured cloning and transfer handlers).
+ */
+export type ProxyOrClone<T> = T extends ProxyMarked ? Remote<T> : T;
+/**
+ * Inverse of `ProxyOrClone<T>`.
+ */
+export type UnproxyOrClone<T> = T extends RemoteObject<ProxyMarked>
+  ? Local<T>
+  : T;
+
+/**
+ * Takes the raw type of a remote object in the other thread and returns the type as it is visible to the local thread
+ * when proxied with `Comlink.proxy()`.
+ *
+ * This does not handle call signatures, which is handled by the more general `Remote<T>` type.
+ *
+ * @template T The raw type of a remote object as seen in the other thread.
+ */
+export type RemoteObject<T> = { [P in keyof T]: RemoteProperty<T[P]> };
+/**
+ * Takes the type of an object as a remote thread would see it through a proxy (e.g. when passed in as a function
+ * argument) and returns the type that the local thread has to supply.
+ *
+ * This does not handle call signatures, which is handled by the more general `Local<T>` type.
+ *
+ * This is the inverse of `RemoteObject<T>`.
+ *
+ * @template T The type of a proxied object.
+ */
+export type LocalObject<T> = { [P in keyof T]: LocalProperty<T[P]> };
+
+/**
+ * Additional special comlink methods available on each proxy returned by `Comlink.wrap()`.
+ */
+export interface ProxyMethods {
+  [createEndpoint]: () => Promise<MessagePort>;
+  [releaseProxy]: () => void;
+}
+
+/**
+ * Takes the raw type of a remote object, function or class in the other thread and returns the type as it is visible to
+ * the local thread from the proxy return value of `Comlink.wrap()` or `Comlink.proxy()`.
+ */
 export type Remote<T> =
-  (
-    T extends (...args: infer R1) => infer R2
-      ? (...args: R1) => Promisify<R2>
-      : unknown
-  ) &
-  (
-    T extends { new (...args: infer R1): infer R2 }
-      ? { new (...args: R1): Promise<Remote<R2>> }
-      : unknown
-  ) &
-  (
-    T extends Object
-      ? { [K in keyof T]: Remote<T[K]> }
-      : unknown
-  ) &
-  (
-    T extends string
-      ? Promise<string>
-      : unknown
-  ) &
-  (
-    T extends number
-      ? Promise<number>
-      : unknown
-  ) &
-  (
-    T extends boolean
-      ? Promise<boolean>
-      : unknown
-  ) & {
-    [createEndpoint]: () => Promise<MessagePort>;
-    [releaseProxy]: () => void;
-  };
+  // Handle properties
+  RemoteObject<T> &
+    // Handle call signature (if present)
+    (T extends (...args: infer TArguments) => infer TReturn
+      ? (
+          ...args: { [I in keyof TArguments]: UnproxyOrClone<TArguments[I]> }
+        ) => Promisify<ProxyOrClone<Unpromisify<TReturn>>>
+      : unknown) &
+    // Handle construct signature (if present)
+    // The return of construct signatures is always proxied (whether marked or not)
+    (T extends { new (...args: infer TArguments): infer TInstance }
+      ? {
+          new (
+            ...args: {
+              [I in keyof TArguments]: UnproxyOrClone<TArguments[I]>;
+            }
+          ): Promisify<RemoteObject<TInstance>>;
+        }
+      : unknown) &
+    // Include additional special comlink methods available on the proxy.
+    ProxyMethods;
 
-declare var x: Remote<number>;
+/**
+ * Expresses that a type can be either a sync or async.
+ */
+type MaybePromise<T> = Promise<T> | T;
 
-declare var y: PromiseLike<number>;
+/**
+ * Takes the raw type of a remote object, function or class as a remote thread would see it through a proxy (e.g. when
+ * passed in as a function argument) and returns the type the local thread has to supply.
+ *
+ * This is the inverse of `Remote<T>`. It takes a `Remote<T>` and returns its original input `T`.
+ */
+export type Local<T> =
+  // Omit the special proxy methods (they don't need to be supplied, comlink adds them)
+  Omit<LocalObject<T>, keyof ProxyMethods> &
+    // Handle call signatures (if present)
+    (T extends (...args: infer TArguments) => infer TReturn
+      ? (
+          ...args: { [I in keyof TArguments]: ProxyOrClone<TArguments[I]> }
+        ) => // The raw function could either be sync or async, but is always proxied automatically
+        MaybePromise<UnproxyOrClone<Unpromisify<TReturn>>>
+      : unknown) &
+    // Handle construct signature (if present)
+    // The return of construct signatures is always proxied (whether marked or not)
+    (T extends { new (...args: infer TArguments): infer TInstance }
+      ? {
+          new (
+            ...args: {
+              [I in keyof TArguments]: ProxyOrClone<TArguments[I]>;
+            }
+          ): // The raw constructor could either be sync or async, but is always proxied automatically
+          MaybePromise<Local<Unpromisify<TInstance>>>;
+        }
+      : unknown);
 
 export interface TransferHandler {
   canHandle(obj: any): boolean;
@@ -317,7 +418,7 @@ export function transfer(obj: any, transfers: Transferable[]) {
   return obj;
 }
 
-export function proxy<T>(obj: T): T & { [proxyMarker]: true } {
+export function proxy<T>(obj: T): T & ProxyMarked {
   return Object.assign(obj, { [proxyMarker]: true }) as any;
 }
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -203,12 +203,16 @@ async function closureSoICanUseAwait() {
     //
 
     // Type round trips
+    // This tests that Local is the exact inverse of Remote for objects:
     assert<
       IsExact<
         Comlink.Local<Comlink.Remote<Comlink.ProxyMarked>>,
         Comlink.ProxyMarked
       >
     >(true);
+    // This tests that Local is the exact inverse of Remote for functions, with one difference:
+    // The local version of a remote function can be either implemented as a sync or async function,
+    // because Remote<T> always makes the function async.
     assert<
       IsExact<
         Comlink.Local<Comlink.Remote<(a: number) => string>>,

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -190,7 +190,9 @@ async function closureSoICanUseAwait() {
       Comlink.windowEndpoint(self)
     );
     const inst1 = await new ProxiedFooClass("test");
-    assert<IsExact<typeof inst1, Comlink.RemoteObject<Foo>>>(true);
+    assert<IsExact<typeof inst1, Comlink.Remote<Foo>>>(true);
+    inst1[Comlink.releaseProxy]();
+    inst1[Comlink.createEndpoint]();
 
     // @ts-expect-error
     // await new ProxiedFooClass(123);

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -102,8 +102,6 @@ async function closureSoICanUseAwait() {
   {
     Comlink.wrap(new MessageChannel().port1);
     Comlink.expose({}, new MessageChannel().port2);
-    const connection = new RTCPeerConnection();
-    const channel = connection.createDataChannel("comlink");
 
     interface Baz {
       baz: number;

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -1,4 +1,11 @@
-import { assert, Has, NotHas, IsAny } from "conditional-type-checks";
+import {
+  assert,
+  Has,
+  NotHas,
+  IsAny,
+  IsExact,
+  IsNever
+} from "conditional-type-checks";
 
 import * as Comlink from "../src/comlink.js";
 
@@ -86,9 +93,263 @@ async function closureSoICanUseAwait() {
     assert<Has<typeof b, () => Promise<number>>>(true);
     assert<IsAny<typeof b>>(false);
     const subproxy = proxy.c;
-    assert<Has<typeof subproxy, { d: Promise<number> }>>(true);
+    assert<Has<typeof subproxy, Promise<{ d: number }>>>(true);
     assert<IsAny<typeof subproxy>>(false);
     const copy = await proxy.c;
     assert<Has<typeof copy, { d: number }>>(true);
+  }
+
+  {
+    Comlink.wrap(new MessageChannel().port1);
+    Comlink.expose({}, new MessageChannel().port2);
+    const connection = new RTCPeerConnection();
+    const channel = connection.createDataChannel("comlink");
+
+    interface Baz {
+      baz: number;
+      method(): number;
+    }
+
+    class Foo {
+      constructor(cParam: string) {
+        const self = this;
+        assert<IsExact<typeof self.proxyProp, Bar & Comlink.ProxyMarked>>(true);
+      }
+      prop1: string = "abc";
+      proxyProp = Comlink.proxy(new Bar());
+      methodWithTupleParams(...args: [string] | [number, string]): number {
+        return 123;
+      }
+      methodWithProxiedReturnValue(): Baz & Comlink.ProxyMarked {
+        return Comlink.proxy({ baz: 123, method: () => 123 });
+      }
+      methodWithProxyParameter(param: Baz & Comlink.ProxyMarked): void {}
+    }
+
+    class Bar {
+      prop2: string | number = "abc";
+      method(param: string): number {
+        return 123;
+      }
+      methodWithProxiedReturnValue(): Baz & Comlink.ProxyMarked {
+        return Comlink.proxy({ baz: 123, method: () => 123 });
+      }
+    }
+    const proxy = Comlink.wrap<Foo>(Comlink.windowEndpoint(self));
+    assert<IsExact<typeof proxy, Comlink.Remote<Foo>>>(true);
+
+    proxy[Comlink.releaseProxy]();
+    const endp = proxy[Comlink.createEndpoint]();
+    assert<IsExact<typeof endp, Promise<MessagePort>>>(true);
+
+    assert<IsAny<typeof proxy.prop1>>(false);
+    assert<Has<typeof proxy.prop1, Promise<string>>>(true);
+
+    const r1 = proxy.methodWithTupleParams(123, "abc");
+    assert<IsExact<typeof r1, Promise<number>>>(true);
+
+    const r2 = proxy.methodWithTupleParams("abc");
+    assert<IsExact<typeof r2, Promise<number>>>(true);
+
+    assert<
+      IsExact<typeof proxy.proxyProp, Comlink.Remote<Bar & Comlink.ProxyMarked>>
+    >(true);
+
+    assert<IsAny<typeof proxy.proxyProp.prop2>>(false);
+    assert<Has<typeof proxy.proxyProp.prop2, Promise<string>>>(true);
+    assert<Has<typeof proxy.proxyProp.prop2, Promise<number>>>(true);
+
+    const r3 = proxy.proxyProp.method("param");
+    assert<IsAny<typeof r3>>(false);
+    assert<Has<typeof r3, Promise<number>>>(true);
+
+    // @ts-expect-error
+    proxy.proxyProp.method(123);
+
+    // @ts-expect-error
+    proxy.proxyProp.method();
+
+    const r4 = proxy.methodWithProxiedReturnValue();
+    assert<IsAny<typeof r4>>(false);
+    assert<
+      IsExact<typeof r4, Promise<Comlink.Remote<Baz & Comlink.ProxyMarked>>>
+    >(true);
+
+    const r5 = proxy.proxyProp.methodWithProxiedReturnValue();
+    assert<
+      IsExact<typeof r5, Promise<Comlink.Remote<Baz & Comlink.ProxyMarked>>>
+    >(true);
+
+    const r6 = (await proxy.methodWithProxiedReturnValue()).baz;
+    assert<IsAny<typeof r6>>(false);
+    assert<Has<typeof r6, Promise<number>>>(true);
+
+    const r7 = (await proxy.methodWithProxiedReturnValue()).method();
+    assert<IsAny<typeof r7>>(false);
+    assert<Has<typeof r7, Promise<number>>>(true);
+
+    const ProxiedFooClass = Comlink.wrap<typeof Foo>(
+      Comlink.windowEndpoint(self)
+    );
+    const inst1 = await new ProxiedFooClass("test");
+    assert<IsExact<typeof inst1, Comlink.RemoteObject<Foo>>>(true);
+
+    // @ts-expect-error
+    await new ProxiedFooClass(123);
+
+    // @ts-expect-error
+    await new ProxiedFooClass();
+
+    //
+    // Tests for advanced proxy use cases
+    //
+
+    // Type round trips
+    assert<
+      IsExact<
+        Comlink.Local<Comlink.Remote<Comlink.ProxyMarked>>,
+        Comlink.ProxyMarked
+      >
+    >(true);
+    assert<
+      IsExact<
+        Comlink.Local<Comlink.Remote<(a: number) => string>>,
+        (a: number) => string | Promise<string>
+      >
+    >(true);
+
+    interface Subscriber<T> {
+      closed?: boolean;
+      next?: (value: T) => void;
+    }
+    interface Unsubscribable {
+      unsubscribe(): void;
+    }
+    /** A Subscribable that can get proxied by Comlink */
+    interface ProxyableSubscribable<T> extends Comlink.ProxyMarked {
+      subscribe(
+        subscriber: Comlink.Remote<Subscriber<T> & Comlink.ProxyMarked>
+      ): Unsubscribable & Comlink.ProxyMarked;
+    }
+
+    /** Simple parameter object that gets cloned (not proxied) */
+    interface Params {
+      textDocument: string;
+    }
+
+    class Registry {
+      async registerProvider(
+        provider: Comlink.Remote<
+          ((params: Params) => ProxyableSubscribable<string>) &
+            Comlink.ProxyMarked
+        >
+      ) {
+        const resultPromise = provider({ textDocument: "foo" });
+        assert<
+          IsExact<
+            typeof resultPromise,
+            Promise<Comlink.Remote<ProxyableSubscribable<string>>>
+          >
+        >(true);
+        const result = await resultPromise;
+
+        const subscriptionPromise = result.subscribe({
+          [Comlink.proxyMarker]: true,
+          next: value => {
+            assert<IsExact<typeof value, string>>(true);
+          }
+        });
+        assert<
+          IsExact<
+            typeof subscriptionPromise,
+            Promise<Comlink.Remote<Unsubscribable & Comlink.ProxyMarked>>
+          >
+        >(true);
+        const subscriber = Comlink.proxy({
+          next: (value: string) => console.log(value)
+        });
+        result.subscribe(subscriber);
+
+        const r1 = (await subscriptionPromise).unsubscribe();
+        assert<IsExact<typeof r1, Promise<void>>>(true);
+      }
+    }
+    const proxy2 = Comlink.wrap<Registry>(Comlink.windowEndpoint(self));
+
+    proxy2.registerProvider(
+      // Synchronous callback
+      Comlink.proxy(({ textDocument }: Params) => {
+        const subscribable = Comlink.proxy({
+          subscribe(
+            subscriber: Comlink.Remote<Subscriber<string> & Comlink.ProxyMarked>
+          ): Unsubscribable & Comlink.ProxyMarked {
+            // Important to test here is that union types (such as Function | undefined) distribute properly
+            // when wrapped in Promises/proxied
+
+            assert<IsAny<typeof subscriber.closed>>(false);
+            assert<
+              IsExact<
+                typeof subscriber.closed,
+                Promise<true> | Promise<false> | Promise<undefined> | undefined
+              >
+            >(true);
+
+            assert<IsAny<typeof subscriber.next>>(false);
+            assert<
+              IsExact<
+                typeof subscriber.next,
+                | Comlink.Remote<(value: string) => void>
+                | Promise<undefined>
+                | undefined
+              >
+            >(true);
+
+            // @ts-expect-error
+            subscriber.next();
+
+            if (subscriber.next) {
+              // Only checking for presence is not enough, since it could be a Promise
+
+              // @ts-expect-error
+              subscriber.next();
+            }
+
+            if (typeof subscriber.next === "function") {
+              subscriber.next("abc");
+            }
+
+            return Comlink.proxy({ unsubscribe() {} });
+          }
+        });
+        assert<Has<typeof subscribable, Comlink.ProxyMarked>>(true);
+        return subscribable;
+      })
+    );
+    proxy2.registerProvider(
+      // Async callback
+      Comlink.proxy(async ({ textDocument }: Params) => {
+        return Comlink.proxy({
+          subscribe(
+            subscriber: Comlink.Remote<Subscriber<string> & Comlink.ProxyMarked>
+          ): Unsubscribable & Comlink.ProxyMarked {
+            assert<IsAny<typeof subscriber.next>>(false);
+            assert<
+              IsExact<
+                typeof subscriber.next,
+                | Comlink.Remote<(value: string) => void>
+                | Promise<undefined>
+                | undefined
+              >
+            >(true);
+
+            // Only checking for presence is not enough, since it could be a Promise
+            if (typeof subscriber.next === "function") {
+              subscriber.next("abc");
+            }
+            return Comlink.proxy({ unsubscribe() {} });
+          }
+        });
+      })
+    );
   }
 }

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -164,10 +164,10 @@ async function closureSoICanUseAwait() {
     assert<Has<typeof r3, Promise<number>>>(true);
 
     // @ts-expect-error
-    proxy.proxyProp.method(123);
+    // proxy.proxyProp.method(123);
 
     // @ts-expect-error
-    proxy.proxyProp.method();
+    // proxy.proxyProp.method();
 
     const r4 = proxy.methodWithProxiedReturnValue();
     assert<IsAny<typeof r4>>(false);
@@ -195,10 +195,10 @@ async function closureSoICanUseAwait() {
     assert<IsExact<typeof inst1, Comlink.RemoteObject<Foo>>>(true);
 
     // @ts-expect-error
-    await new ProxiedFooClass(123);
+    // await new ProxiedFooClass(123);
 
     // @ts-expect-error
-    await new ProxiedFooClass();
+    // await new ProxiedFooClass();
 
     //
     // Tests for advanced proxy use cases
@@ -305,13 +305,12 @@ async function closureSoICanUseAwait() {
             >(true);
 
             // @ts-expect-error
-            subscriber.next();
+            // subscriber.next();
 
             if (subscriber.next) {
               // Only checking for presence is not enough, since it could be a Promise
-
               // @ts-expect-error
-              subscriber.next();
+              // subscriber.next();
             }
 
             if (typeof subscriber.next === "function") {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,5 +53,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
This fixes the typings issues described in #432.

- `Promisify<T>` needs to check first whether `T extends Promise` already. Otherwise it could resolve to `Promise<Promise<T>>` if `T` already is a Promise  (which is impossible in comlink and JavaScript in general).
 
- In the mapped types, each right side generally needs to be extracted into its own type alias. This is because generic type aliases will distribute over union types, while inlining the type would not. This means the type would not work properly when union types are involved. This may sound like an edge case, but includes e.g. optional properties, which are union types `xxx | undefined`.
 
- (most complicated part) For proxied functions, while the return type needs to be wrapped in `Remote<T>`, the parameters of the functions need to have the _inverse_ applied. This is because from the point of view of the function implementation, passed callbacks will now return Promises, and therefor they need to type their signature accordingly. But the caller does not actually need to provide a callback that returns a Promise, from the point of view of the caller it just needs to pass a synchronous callback.
   - This means the library needs to define symmetric, recursive types for "remotification" and "deremotification". Within either, parameters get treated with the inverse transformation respectively, recursively.
   - The new methods `[releaseProxy]` and `[createEndpoint]` also need to be considered (i.e. not required to be provided by a caller).

The first commit adds tests that fail on master. I upgraded to TypeScript 3.9 to get access to `@ts-expect-error` and added a tsconfig.json so that strict mode is applied to the tests too.

The second commit overhauls the actual types to fix all the failing tests.

I did my best to write as many comments as possible to explain them, but the types are no doubt complex. The result is that users don't have to worry about any of this because it "just works" under the hood :)

Also fixes https://github.com/GoogleChromeLabs/comlink/pull/424 in a type-safe way.