### PR TITLE
Improve transfer handler typings

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -54,7 +54,7 @@ export interface HandlerWireValue {
   id?: string;
   type: WireValueType.HANDLER;
   name: string;
-  value: {};
+  value: unknown;
 }
 
 export type WireValue = RawWireValue | HandlerWireValue;

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -162,6 +162,21 @@ describe("Comlink in the same realm", function() {
     }
   });
 
+  it("can rethrow null", async function() {
+    const thing = Comlink.wrap(this.port1);
+    Comlink.expose(_ => {
+      throw null;
+    }, this.port2);
+    try {
+      await thing();
+      throw "Should have thrown";
+    } catch (err) {
+      expect(err).to.not.equal("Should have thrown");
+      expect(err).to.equal(null);
+      expect(typeof err).to.equal("object");
+    }
+  });
+
   it("can work with parameterized functions", async function() {
     const thing = Comlink.wrap(this.port1);
     Comlink.expose((a, b) => a + b, this.port2);

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -1,11 +1,4 @@
-import {
-  assert,
-  Has,
-  NotHas,
-  IsAny,
-  IsExact,
-  IsNever
-} from "conditional-type-checks";
+import { assert, Has, NotHas, IsAny, IsExact } from "conditional-type-checks";
 
 import * as Comlink from "../src/comlink.js";
 
@@ -354,5 +347,24 @@ async function closureSoICanUseAwait() {
         });
       })
     );
+  }
+
+  // Transfer handlers
+  {
+    const urlTransferHandler: Comlink.TransferHandler<URL, string> = {
+      canHandle: (val): val is URL => {
+        assert<IsExact<typeof val, unknown>>(true);
+        return val instanceof URL;
+      },
+      serialize: url => {
+        assert<IsExact<typeof url, URL>>(true);
+        return [url.href, []];
+      },
+      deserialize: str => {
+        assert<IsExact<typeof str, string>>(true);
+        return new URL(str);
+      }
+    };
+    Comlink.transferHandlers.set("URL", urlTransferHandler);
   }
 }


### PR DESCRIPTION
This is a simple improvement to make transfer handlers type-safe instead of using `any`. This allows all types to be inferred (see the tests) and I think it also helps communicating how they work. It would also help in informing users when the API changes - e.g. I missed that from v3 to v4 the interface of `serialize()` was changed to return a tuple because it was typed `any`.

The deserialized type is required to be the same as the input because otherwise it would be impossible to type basically anything about proxied objects, so this ensures an important invariant. The internal proxy transfer handler technically has a different return type, but because it is internal we can consider it in the typings, which we cannot do with user transfer handlers. This is generally how people would use them, and for any edge cases casting is still possible.

I kept the functionality 100% the same.

One thing I noticed is that currently the throw error handler does not work for thrown scalars (e.g. strings): https://github.com/GoogleChromeLabs/comlink/issues/409
(but this doesn't block improving the typings)

