### PR TITLE
Mark comlink as not having side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/umd/comlink.js",
   "module": "dist/esm/comlink.mjs",
   "types": "dist/umd/comlink.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "rollup -c",
     "test:unit": "karma start",


### PR DESCRIPTION
Importing comlink does not have any side effects. However, bundlers like Rollup are unable to determine this because `comlink.ts` instantiates a Map and a WeakMap:

https://github.com/GoogleChromeLabs/comlink/blob/c69224eb4e33076df68d7ac8ed14be2cff7a3962/src/comlink.ts#L276

https://github.com/GoogleChromeLabs/comlink/blob/c69224eb4e33076df68d7ac8ed14be2cff7a3962/src/comlink.ts#L470

By adding `sideEffects: false` to `package.json`, Comlink will indicate to bundlers that they can safely drop the Comlink import if none of the exports are used.

For example, Rollup will read the `sideEffects` value in the `node-resolve` plugin here: https://github.com/rollup/plugins/blob/867c69990a27ee234a4babdf2dd24151cd4d5e55/packages/node-resolve/src/util.js#L138-L140

