### PR TITLE
Fix disabled test

### DIFF
--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -324,11 +324,7 @@ async function closureSoICanUseAwait() {
     proxy2.registerProvider(
       // Async callback
       Comlink.proxy(async ({ textDocument }: Params) => {
-        // Disabling this test here for now as there seems to be a bug with the
-        // TypeScript compiler. It claims that this function does not return
-        // a proxy-marked value.
-        // @ts-expect-error
-        return Comlink.proxy({
+        const subscribable = Comlink.proxy({
           subscribe(
             subscriber: Comlink.Remote<Subscriber<string> & Comlink.ProxyMarked>
           ): Unsubscribable & Comlink.ProxyMarked {
@@ -349,6 +345,7 @@ async function closureSoICanUseAwait() {
             return Comlink.proxy({ unsubscribe() {} });
           },
         });
+        return subscribable;
       })
     );
   }


### PR DESCRIPTION
Fixes #471

It seems that when the return from `comlink.proxy()` is directly returned, there is a problem with type inference where the compiler does not infer the right type. Maybe it triggers some usage-based inference that is invalid in this scenario. When assigning it first to a variable, the type is inferred correctly for the variable, and then returning that variable works.

We were actually doing the same workaround in the test for the synchronous case, which exhibits the same problem. But for some reason the issue wasn't present when using an `async` function, but is now as of `v3.9.3`.

@DanielRosenwasser do you have any idea what's going on here? Should this be filed as a bug in TypeScript?