### PR TITLE
Handle custom error properties

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -249,6 +249,7 @@ const throwTransferHandler: TransferHandler<
       serialized = {
         isError: true,
         value: {
+          ...value,
           message: value.message,
           name: value.name,
           stack: value.stack,

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -116,6 +116,26 @@ describe("Comlink in the same realm", function () {
     }
   });
 
+  it("can keep properties of custom errors", async function () {
+    const thing = Comlink.wrap(this.port1);
+    Comlink.expose((_) => {
+      class CustomError extends Error {
+        constructor(message, data) {
+          super(message);
+          this.data = data;
+        }
+      }
+      throw new CustomError("OMG", "extra error details");
+    }, this.port2);
+    try {
+      await thing();
+      throw "Should have thrown";
+    } catch (err) {
+      expect(err).to.not.eq("Should have thrown");
+      expect(err.data).to.equal("extra error details");
+    }
+  });
+
   it("can forward an async function error", async function () {
     const thing = Comlink.wrap(this.port1);
     Comlink.expose(


### PR DESCRIPTION
I have a situation where I am using an Error subclass in a worker thread. Extra data attached to the custom Error isn't passed back across to the main thread!

This little fix handles that case! 🎉