### PR TITLE
Fixes issue #466

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@rollup/plugin-replace": "^2.4.2",
     "chai": "4.2.0",
     "conditional-type-checks": "1.0.5",
     "husky": "4.2.5",
@@ -46,7 +47,7 @@
     "prettier": "2.0.5",
     "rimraf": "3.0.2",
     "rollup": "^2.11.2",
-    "rollup-plugin-terser": "^6.1.0",
+    "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.27.1",
     "typescript": "^3.9.3"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     "module": "esnext" /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
       "esnext",
-      "dom"
+      "dom",
+      "WebWorker",
+      "ES2015.Promise"
     ] /* Specify library files to be included in the compilation:  */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -23,6 +25,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
+    "skipLibCheck": true,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */


### PR DESCRIPTION
The fix is conceptually really simple: use a dynamic `import` (or `require` under cjs) to import `MessageChannel` from node's `worker_threads` module if we detect that the browser's instance of `MessageChannel` is undefined. 

Nevertheless, this turned out to be more complicated that it should due to the lack of widespread support for TLA (top-level await).  So, unfortunately, the fix is only available for the `umd` bundle, otherwise the `esm` bundle would just work on node and would break when running on browsers.

I've put comments on the code explaining that when TLA are widely available this can be fix for both module systems.