### PR TITLE
Fixed string-channel to work with callbacks

### DIFF
--- a/src/string-channel.experimental.ts
+++ b/src/string-channel.experimental.ts
@@ -230,6 +230,7 @@ function makeTransferable(
         findAllTransferables(data).map(v => v.value)
       );
     });
+    wrapped.start();
 
     return {
       type: SerializedTransferableType.MessagePort,

--- a/tests/string-channel.test.js
+++ b/tests/string-channel.test.js
@@ -13,6 +13,7 @@
 
 import "/base/node_modules/web-streams-polyfill/dist/polyfill.es2018.js";
 import { wrap } from "/base/dist/esm/string-channel.experimental.mjs";
+import * as Comlink from "/base/dist/esm/comlink.mjs";
 
 describe("StringChannel", function() {
   beforeEach(function() {
@@ -104,6 +105,19 @@ describe("StringChannel", function() {
     });
     this.ep2.start();
     this.ep1.postMessage(originalMessage);
+  });
+
+  it("can transfer Callbacks", async function() {
+    const originalObj = { a: () => Promise.resolve(false) };
+    Comlink.expose(originalObj, this.ep1);
+    const remoteObj = Comlink.wrap(this.ep2);
+
+    // This set action is asynchronous no way to await here
+    remoteObj.a = Comlink.proxy(() => true);
+    // Waiting for setter to actually activate
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const result = await originalObj.a();
+    expect(result).to.be.true;
   });
 });
 

--- a/tests/string-channel.test.js
+++ b/tests/string-channel.test.js
@@ -107,7 +107,7 @@ describe("StringChannel", function() {
     this.ep1.postMessage(originalMessage);
   });
 
-  it("can transfer Callbacks", async function() {
+  it("can transfer and call Callbacks", async function() {
     const originalObj = { a: () => Promise.resolve(false) };
     Comlink.expose(originalObj, this.ep1);
     const remoteObj = Comlink.wrap(this.ep2);


### PR DESCRIPTION
I know this is just experimental, but it might help for someone like me.

Callbacks weren't working.
* added added fix for it (calling .start() on wrapped MessagePort)
* added a test to prove it's working now
