### PR TITLE
Namespaced APIs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@
 # Names should be added to this file as:
 #     Name <email address>
 Surma <surma@google.com>
+Menecats <d.menegatti@recrosoftware.com>

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ onconnect = function (event) {
 ### [`Namespaces`](./docs/examples/08-namespaces-example)
 
 When you need to expose more objects from a thread you can use Comlink's namespaced APIs.
-This APIs allows you to independently expose objects and access them later from the main thread.
+These APIs allow you to independently expose objects and access them later from the main thread.
 
-**Note:** Also the `expose` and `wrap` APIs uses namespaces under the hood, they uses the default `Comlink.default` namespace.
+**Note:** Also the `expose` and `wrap` APIs use namespaces under the hood, they use the default `Comlink.default` namespace.
 
 **main.js**
 
@@ -215,7 +215,7 @@ Comlink’s goal is to make _exposed_ values from one thread available in the ot
 
 ### `Comlink.wrapNamespaced(endpoint, namespace)` and `Comlink.exposeNamespaced(value, namespace, endpoint?)`
 
-To allow one thread to _expose_ more that one object independently from other objects already _exposed_ Comlink allows you to specify a custom namespace.
+To allow one thread to _expose_ more than one object independently from other objects already _exposed_ Comlink allows you to specify a custom namespace.
 
 The `expose` API uses `exposeNamespaced` with `Comlink.default` as the default namespace.
 
@@ -274,9 +274,9 @@ Note that this particular transfer handler won’t create an actual `Event`, but
 
 ### `Comlink.defaultNamespace`
 
-This constant hold the value of the default namespace used by `Comlink.wrap` and `Comlink.expose`.
+This constant holds the value of the default namespace used by `Comlink.wrap` and `Comlink.expose`.
 
-It's value is `Comlink.default`.
+Its value is `Comlink.default`.
 
 ### `Comlink.releaseProxy`
 

--- a/docs/examples/08-namespaces-example/README.md
+++ b/docs/examples/08-namespaces-example/README.md
@@ -1,1 +1,1 @@
-This example shows how to expose multiple object under different namespaces.
+This example shows how to expose multiple objects under different namespaces.

--- a/docs/examples/08-namespaces-example/README.md
+++ b/docs/examples/08-namespaces-example/README.md
@@ -1,0 +1,1 @@
+This example shows how to expose multiple object under different namespaces.

--- a/docs/examples/08-namespaces-example/index.html
+++ b/docs/examples/08-namespaces-example/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+<script type="module">
+  import * as Comlink from "https://unpkg.com/comlink/dist/esm/comlink.mjs";
+  // import * as Comlink from "../../../dist/esm/comlink.mjs";
+
+  async function init() {
+    // WebWorkers use `postMessage` and therefore work with Comlink.
+    const worker = new Worker("worker.js");
+
+    // 'wrap' uses the default namespace (Comlink.default)
+    const obj1 = Comlink.wrap(worker);
+
+    // this will connect to the 'my-namespace' namespace.
+    const obj2 = Comlink.wrapNamespaced(worker, "my-namespace");
+
+    alert(await obj2.sayHi("user"));
+
+    alert(`Counter: ${await obj1.counter}`);
+    await obj1.inc();
+    alert(`Counter: ${await obj1.counter}`);
+  }
+
+  init();
+</script>

--- a/docs/examples/08-namespaces-example/worker.js
+++ b/docs/examples/08-namespaces-example/worker.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+importScripts("https://unpkg.com/comlink/dist/umd/comlink.js");
+// importScripts("../../../dist/umd/comlink.js");
+
+const obj1 = {
+  counter: 0,
+  inc() {
+    this.counter++;
+  },
+};
+
+const obj2 = {
+  sayHi(name) {
+    return "Hi, " + name;
+  },
+};
+
+// 'expose' uses the default namespace (Comlink.default)
+Comlink.expose(obj1);
+
+// this will expose obj2 under the 'my-namespace' namespace
+Comlink.exposeNamespaced(obj2, "my-namespace");

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -47,13 +47,15 @@ export const enum WireValueType {
 }
 
 export interface RawWireValue {
-  id?: string;
+  id?: MessageID;
+  namespace?: MessageNamespace;
   type: WireValueType.RAW;
   value: {};
 }
 
 export interface HandlerWireValue {
-  id?: string;
+  id?: MessageID;
+  namespace?: MessageNamespace;
   type: WireValueType.HANDLER;
   name: string;
   value: unknown;
@@ -62,6 +64,7 @@ export interface HandlerWireValue {
 export type WireValue = RawWireValue | HandlerWireValue;
 
 export type MessageID = string;
+export type MessageNamespace = string;
 
 export const enum MessageType {
   GET = "GET",
@@ -74,12 +77,14 @@ export const enum MessageType {
 
 export interface GetMessage {
   id?: MessageID;
+  namespace?: MessageNamespace;
   type: MessageType.GET;
   path: string[];
 }
 
 export interface SetMessage {
   id?: MessageID;
+  namespace?: MessageNamespace;
   type: MessageType.SET;
   path: string[];
   value: WireValue;
@@ -87,6 +92,7 @@ export interface SetMessage {
 
 export interface ApplyMessage {
   id?: MessageID;
+  namespace?: MessageNamespace;
   type: MessageType.APPLY;
   path: string[];
   argumentList: WireValue[];
@@ -94,6 +100,7 @@ export interface ApplyMessage {
 
 export interface ConstructMessage {
   id?: MessageID;
+  namespace?: MessageNamespace;
   type: MessageType.CONSTRUCT;
   path: string[];
   argumentList: WireValue[];
@@ -101,11 +108,13 @@ export interface ConstructMessage {
 
 export interface EndpointMessage {
   id?: MessageID;
+  namespace?: MessageNamespace;
   type: MessageType.ENDPOINT;
 }
 
 export interface ReleaseMessage {
   id?: MessageID;
+  namespace?: MessageNamespace;
   type: MessageType.RELEASE;
   path: string[];
 }

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -319,6 +319,23 @@ describe("Comlink in the same realm", function () {
     expect(await instance._counter).to.equal(4);
   });
 
+  it("can work different namespaces", async function () {
+    const objDefault = { value: "default" };
+    const objNamespaced = { value: "custom" };
+
+    const proxyDefault = Comlink.wrap(this.port1);
+    Comlink.expose(objDefault, this.port2);
+
+    const proxyNamespaced = Comlink.wrapNamespaced(
+      this.port1,
+      "custom-namespace"
+    );
+    Comlink.exposeNamespaced(objNamespaced, "custom-namespace", this.port2);
+
+    expect(await proxyDefault.value).to.equal(objDefault.value);
+    expect(await proxyNamespaced.value).to.equal(objNamespaced.value);
+  });
+
   const hasBroadcastChannel = (_) => "BroadcastChannel" in self;
   guardedIt(hasBroadcastChannel)(
     "will work with BroadcastChannel",


### PR DESCRIPTION
This PR introduces the concept of namespaced proxies.

With these chenges it's now possible to expose multiple objects from a single worker.

E.g.

**worker.js**
```javascript
const authentication = {
  login: function (username, password) {
    return Math.random() < .5;
  }
};
const logger = {
  log: function (message) {
    console.log(message);
  }
};
const obj = {
  counter: 0,
  inc() {
    this.counter++;
  }
};

Comlink.expose(obj);
Comlink.exposeNamespaced(authentication, 'auth-namespace');
Comlink.exposeNamespaced(logger, 'log-namespace');
```

**main.js**
```javascript
const worker = new Worker("worker.js");

const obj = Comlink.wrap(worker);
const auth = Comlink.wrapNamespaced(worker, 'auth-namespace');
const logger = Comlink.wrapNamespaced(worker, 'log-namespace');

if (await auth.login('my-username', 's3cr3t pwd!')) {
  await obj.inc();
  await logger.log(await obj.counter));
} else {
  await logger.log('Invalid credentials');
}
```