### PR TITLE
Unserializable return type error

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -368,6 +368,13 @@ export function expose(
             obj[finalizer]();
           }
         }
+      }).catch((error) => {
+        // Send Serialization Error To Caller
+        const [wireValue, transferables] = toWireValue({ 
+          value: new TypeError("Unserializable return value"),
+          [throwMarker]: 0
+        });
+        ep.postMessage({ ...wireValue, id }, transferables);
       });
   } as any);
   if (ep.start) {

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -368,11 +368,12 @@ export function expose(
             obj[finalizer]();
           }
         }
-      }).catch((error) => {
+      })
+      .catch((error) => {
         // Send Serialization Error To Caller
-        const [wireValue, transferables] = toWireValue({ 
+        const [wireValue, transferables] = toWireValue({
           value: new TypeError("Unserializable return value"),
-          [throwMarker]: 0
+          [throwMarker]: 0,
         });
         ep.postMessage({ ...wireValue, id }, transferables);
       });

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -637,6 +637,17 @@ describe("Comlink in the same realm", function () {
     Comlink.expose({ value: 4 }, this.port2);
     expect(await thing.value).to.equal(4);
   });
+
+  it("can handle unserializable types", async function () {
+    const thing = Comlink.wrap(this.port1, { value: {}});
+    Comlink.expose({ value: () => 'boom'}, this.port2);
+    
+    try {
+      await thing.value;
+    } catch (err) {
+      expect(err.message).to.equal("Unserializable return value");
+    }
+  });
 });
 
 function guardedIt(f) {


### PR DESCRIPTION
When an unserializable type is returned such as a function, this results in an uncaught error. In Deno, this crashes the application. This change catches the error and returns a serialized error type so that it can be handled by the calling thread.

According to the MDN, there are currently two types of objects that do not work with the structured clone algorithm and will result in a DataCloneError: "a function" and "a DOM node".