### PR TITLE
Consolidate path to string map and parameter type

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -375,7 +375,7 @@ function throwIfProxyReleased(isReleased: boolean) {
 
 function createProxy<T>(
   ep: Endpoint,
-  path: (string | number | symbol)[] = [],
+  path: PropertyKey[] = [],
   target: object = function () {}
 ): Remote<T> {
   let isProxyReleased = false;
@@ -386,7 +386,7 @@ function createProxy<T>(
         return () => {
           return requestResponseMessage(ep, {
             type: MessageType.RELEASE,
-            path: path.map((p) => p.toString()),
+            path: path.map(String),
           }).then(() => {
             closeEndPoint(ep);
             isProxyReleased = true;
@@ -399,7 +399,7 @@ function createProxy<T>(
         }
         const r = requestResponseMessage(ep, {
           type: MessageType.GET,
-          path: path.map((p) => p.toString()),
+          path: path.map(String),
         }).then(fromWireValue);
         return r.then.bind(r);
       }
@@ -414,7 +414,7 @@ function createProxy<T>(
         ep,
         {
           type: MessageType.SET,
-          path: [...path, prop].map((p) => p.toString()),
+          path: [...path, prop].map(String),
           value,
         },
         transferables
@@ -437,7 +437,7 @@ function createProxy<T>(
         ep,
         {
           type: MessageType.APPLY,
-          path: path.map((p) => p.toString()),
+          path: path.map(String),
           argumentList,
         },
         transferables
@@ -450,7 +450,7 @@ function createProxy<T>(
         ep,
         {
           type: MessageType.CONSTRUCT,
-          path: path.map((p) => p.toString()),
+          path: path.map(String),
           argumentList,
         },
         transferables


### PR DESCRIPTION
Hello 👋 

While familiarizing myself with the library, I noticed some small opportunities for consolidation:
- Use built-in `PropertyKey` type instead of `string | number | symbol` union
- Use `.map(String)` instead of `.map((p) => p.toString())`

These updates have no meaningful impact on the behavior or functionality of the library. Therefore, feel free to close this PR if the suggestions are deemed unnecessary 🙂 