### PR TITLE
Use shorter SPDX @license headers

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -1,14 +1,7 @@
 /**
- * Copyright 2019 Google Inc. All Rights Reserved.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *     http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import {

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -1,14 +1,7 @@
 /**
- * Copyright 2019 Google Inc. All Rights Reserved.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *     http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { Endpoint } from "./protocol";

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,14 +1,7 @@
 /**
- * Copyright 2019 Google Inc. All Rights Reserved.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *     http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 export interface EventSource {


### PR DESCRIPTION
This PR changes the license headers on the `.ts` source files in the following ways:

1. Adds a `@license` annotation, so that tools like Terser and Closure compiler will automatically know to preserve these license headers by default.

2. Uses a new, more concise style of header with the `SPDX-License-Identifier` property, which is approved by Google's open source office (e.g. it's [used by Lit](https://github.com/lit/lit/blob/main/packages/lit-html/src/lit-html.ts)).