### PR TITLE
fix type checking of nest property accessing

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -61,7 +61,12 @@ type RemoteProperty<T> =
   // If the value is a method, comlink will proxy it automatically.
   // Objects are only proxied if they are marked to be proxied.
   // Otherwise, the property is converted to a Promise that resolves the cloned value.
-  T extends Function | ProxyMarked ? Remote<T> : Promisify<T>;
+  T extends Function | ProxyMarked
+    ? Remote<T>
+    : Promisify<T> &
+        (T extends Record<keyof any, unknown>
+          ? { [P in keyof T]: RemoteProperty<T[P]> }
+          : unknown);
 
 /**
  * Takes the raw type of a property as a remote thread would see it through a proxy (e.g. when passed in as a function

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -86,6 +86,7 @@ async function closureSoICanUseAwait() {
     assert<Has<typeof b, () => Promise<number>>>(true);
     assert<IsAny<typeof b>>(false);
     const subproxy = proxy.c;
+    assert<Has<typeof subproxy, { d: Promise<number> }>>(true);
     assert<Has<typeof subproxy, Promise<{ d: number }>>>(true);
     assert<IsAny<typeof subproxy>>(false);
     const copy = await proxy.c;


### PR DESCRIPTION
```ts
    const x = {
      a: 4,
      b() {
        return 9;
      },
      c: {
        d: 3,
      },
    };

    const proxy = Comlink.wrap<typeof x>(0 as any);

    console.log(await proxy.c.d)
```


This code prompts the following type error:
```
Property 'd' does not exist on type 'Promise<{ d: number; }>'.
```
However, this code should work normally as expected. It actually prints `3` to the console.