### PR TITLE
Add origin filtering for expose

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -285,7 +285,7 @@ function isAllowedOrigin(
   allowedOrigins: (string | RegExp)[],
   origin: string
 ): boolean {
-  for (const allowedOrigin of origins) {
+  for (const allowedOrigin of allowedOrigins) {
     if (origin === allowedOrigin || allowedOrigin === "*") {
       return true;
     }
@@ -299,13 +299,13 @@ function isAllowedOrigin(
 export function expose(
   obj: any,
   ep: Endpoint = self as any,
-  origins: (string | RegExp)[] = ["*"]
+  allowedOrigins: (string | RegExp)[] = ["*"]
 ) {
   ep.addEventListener("message", function callback(ev: MessageEvent) {
     if (!ev || !ev.data) {
       return;
     }
-    if (!isAllowedOrigin(origins, ev.origin)) {
+    if (!isAllowedOrigin(allowedOrigins, ev.origin)) {
       console.warn(`Invalid origin '${ev.origin}' for comlink proxy`);
       return;
     }

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -282,7 +282,7 @@ export const transferHandlers = new Map<
 ]);
 
 function isAllowedOrigin(
-  origins: (string | RegExp)[],
+  allowedOrigins: (string | RegExp)[],
   origin: string
 ): boolean {
   for (const allowedOrigin of origins) {

--- a/tests/cross-origin.comlink.test.js
+++ b/tests/cross-origin.comlink.test.js
@@ -27,7 +27,7 @@ describe("Comlink origin filtering", function () {
           // tell the iframe it can start the attack
           ifr.contentWindow.postMessage("start", "*");
         } else if (ev.data === "done") {
-          // confirm the attack succeeded
+          // confirm the attack failed, the prototype was not updated
           expect(Object.prototype.foo).to.be.undefined;
           expect(obj.my).to.equal("value");
           resolve();
@@ -60,7 +60,7 @@ describe("Comlink origin filtering", function () {
           // tell the iframe it can start the attack
           ifr.contentWindow.postMessage("start", "*");
         } else if (ev.data === "done") {
-          // confirm the attack succeeded
+          // confirm the attack succeeded, the prototype was updated
           expect(Object.prototype.foo).to.equal("x");
           expect(obj.my).to.equal("value");
           resolve();

--- a/tests/cross-origin.comlink.test.js
+++ b/tests/cross-origin.comlink.test.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Comlink from "/base/dist/esm/comlink.mjs";
+
+describe("Comlink origin filtering", function () {
+  it("rejects messages from unknown origin", async function () {
+    // expose on our window so comlink is listening to window postmessage
+    const obj = { my: "value" };
+    Comlink.expose(obj, self, [/^http:\/\/localhost(:[0-9]+)?\/?$/]);
+
+    let handler;
+    // juggle async timings to get the attack started
+    const attackComplete = new Promise((resolve, reject) => {
+      handler = (ev) => {
+        if (ev.data === "ready" && ev.origin === "null") {
+          // tell the iframe it can start the attack
+          ifr.contentWindow.postMessage("start", "*");
+        } else if (ev.data === "done") {
+          // confirm the attack succeeded
+          expect(Object.prototype.foo).to.be.undefined;
+          expect(obj.my).to.equal("value");
+          resolve();
+        }
+      };
+      window.addEventListener("message", handler);
+    });
+    // create a sandboxed iframe for the attack
+    const ifr = document.createElement("iframe");
+    ifr.sandbox.add("allow-scripts");
+    ifr.src = "/base/tests/fixtures/attack-iframe.html";
+    document.body.appendChild(ifr);
+    // wait for the iframe to load
+    await new Promise((resolve) => (ifr.onload = resolve));
+    // and wait for the attack to complete
+    await attackComplete;
+    window.removeEventListener("message", handler);
+    ifr.remove();
+  });
+  it("accepts messages from matching origin", async function () {
+    // expose on our window so comlink is listening to window postmessage
+    const obj = { my: "value" };
+    Comlink.expose(obj, self, [/^http:\/\/localhost(:[0-9]+)?\/?$/]);
+
+    let handler;
+    // juggle async timings to get the attack started
+    const attackComplete = new Promise((resolve, reject) => {
+      handler = (ev) => {
+        if (ev.data === "ready" && ev.origin === window.origin) {
+          // tell the iframe it can start the attack
+          ifr.contentWindow.postMessage("start", "*");
+        } else if (ev.data === "done") {
+          // confirm the attack succeeded
+          expect(Object.prototype.foo).to.equal("x");
+          expect(obj.my).to.equal("value");
+          resolve();
+        }
+      };
+      window.addEventListener("message", handler);
+    });
+    // create a sandboxed iframe for the attack, but with same origin
+    const ifr = document.createElement("iframe");
+    ifr.sandbox.add("allow-scripts", "allow-same-origin");
+    ifr.src = "/base/tests/fixtures/attack-iframe.html";
+    document.body.appendChild(ifr);
+    // wait for the iframe to load
+    await new Promise((resolve) => (ifr.onload = resolve));
+    // and wait for the attack to complete
+    await attackComplete;
+    window.removeEventListener("message", handler);
+    ifr.remove();
+  });
+});

--- a/tests/fixtures/attack-iframe.html
+++ b/tests/fixtures/attack-iframe.html
@@ -1,0 +1,21 @@
+<html>
+  <body>
+    <script>
+      window.addEventListener("message", (ev) => {
+        if (ev.data === "start") {
+          // send back a message to modify the prototype
+          parent.postMessage(
+            {
+              type: "SET",
+              value: { type: "RAW", value: "x" },
+              path: ["__proto__", "foo"],
+            },
+            "*"
+          );
+          parent.postMessage("done", "*");
+        }
+      });
+      parent.postMessage("ready", "*");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Partial fix for #603 allowing a user to specify an origin filtering regexp/string array to control which origins comlink will listen to.

Not sure if a full fix for #603 would require prevention of prototype changes, but I feel like if you `expose` on window you're always going to be a bit vulnerable unless you specify a filtering origin.