### PR TITLE
Upgrades numerous dependencies

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm test

--- a/package.json
+++ b/package.json
@@ -16,11 +16,6 @@
     "fmt_test": "test $(prettier -l './*.{mjs,js,ts,md,json,html}' './{src,docs,tests}/{**/,}*.{mjs,js,ts,md,json,html}' | wc -l) -eq 0",
     "watchtest": "CHROME_ONLY=1 karma start --no-single-run"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm test"
-    }
-  },
   "author": {
     "name": "Surma",
     "email": "surma@google.com"
@@ -31,24 +26,24 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "4.2.0",
-    "conditional-type-checks": "1.0.5",
-    "husky": "4.2.5",
-    "karma": "^5.0.9",
+    "@rollup/plugin-terser": "0.4.0",
+    "@rollup/plugin-typescript": "11.0.0",
+    "chai": "4.3.7",
+    "conditional-type-checks": "1.0.6",
+    "husky": "8.0.3",
+    "karma": "6.4.1",
     "karma-chai": "0.1.0",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "3.1.1",
     "karma-detect-browsers": "2.3.3",
-    "karma-firefox-launcher": "1.3.0",
+    "karma-firefox-launcher": "2.1.2",
     "karma-mocha": "^2.0.1",
     "karma-safari-launcher": "1.0.0",
     "karma-safaritechpreview-launcher": "2.0.2",
-    "mocha": "^7.2.0",
-    "prettier": "2.0.5",
-    "rimraf": "3.0.2",
-    "rollup": "^2.11.2",
-    "rollup-plugin-terser": "^6.1.0",
-    "rollup-plugin-typescript2": "^0.27.1",
-    "typescript": "^3.9.3"
-  },
-  "dependencies": {}
+    "mocha": "^10.2.0",
+    "prettier": "2.8.3",
+    "rimraf": "4.1.2",
+    "rollup": "3.10.1",
+    "tslib": "^2.4.1",
+    "typescript": "4.9.4"
+  }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,5 +1,6 @@
-import typescript from "rollup-plugin-typescript2";
-import { terser } from "rollup-plugin-terser";
+import typescript from "@rollup/plugin-typescript";
+import terser from "@rollup/plugin-terser";
+import { sync } from "rimraf";
 
 function config({ format, minify, input, ext = "js" }) {
   const dir = `dist/${format}/`;
@@ -14,15 +15,12 @@ function config({ format, minify, input, ext = "js" }) {
     },
     plugins: [
       typescript({
-        clean: true,
-        typescript: require("typescript"),
-        tsconfigOverride: {
-          compilerOptions: {
-            sourceMap: true,
-          },
-          // Don’t ask. Without this, the typescript plugin is convinced
-          // to create subfolders and misplace the .d.ts files.
-          files: ["./src/comlink.ts", "./src/protocol.ts"],
+        tsconfig: "./tsconfig.json",
+        compilerOptions: {
+          declaration: true,
+          declarationDir: ".",
+          sourceMap: true,
+          outDir: "dist",
         },
       }),
       minify
@@ -35,7 +33,7 @@ function config({ format, minify, input, ext = "js" }) {
   };
 }
 
-require("rimraf").sync("dist");
+sync("dist");
 
 export default [
   { input: "comlink", format: "esm", minify: false, ext: "mjs" },

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -543,7 +543,7 @@ export function transfer<T>(obj: T, transfers: Transferable[]): T {
   return obj;
 }
 
-export function proxy<T>(obj: T): T & ProxyMarked {
+export function proxy<T extends {}>(obj: T): T & ProxyMarked {
   return Object.assign(obj, { [proxyMarker]: true }) as any;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,5 +54,6 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
 }


### PR DESCRIPTION
We have a number of PRs open from renovate bot prompting some updates to dependencies, many of which are several major versions out of date now. This PR upgrades them all.

Should close the following PRs #488, #494, #498, #517, #527, #535, #536, #582

Also fixes one small type issue that arose with the upgrade to TS.