### PR TITLE
Replace `self` with `globalThis` for use in Worklets

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -292,7 +292,7 @@ function isAllowedOrigin(
 
 export function expose(
   obj: any,
-  ep: Endpoint = self as any,
+  ep: Endpoint = globalThis as any,
   allowedOrigins: (string | RegExp)[] = ["*"]
 ) {
   ep.addEventListener("message", function callback(ev: MessageEvent) {
@@ -422,7 +422,7 @@ declare var FinalizationRegistry: FinalizationRegistry<Endpoint>;
 
 const proxyCounter = new WeakMap<Endpoint, number>();
 const proxyFinalizers =
-  "FinalizationRegistry" in self &&
+  "FinalizationRegistry" in globalThis &&
   new FinalizationRegistry((ep: Endpoint) => {
     const newCount = (proxyCounter.get(ep) || 0) - 1;
     proxyCounter.set(ep, newCount);
@@ -550,7 +550,7 @@ export function proxy<T extends {}>(obj: T): T & ProxyMarked {
 
 export function windowEndpoint(
   w: PostMessageWithOrigin,
-  context: EventSource = self,
+  context: EventSource = globalThis,
   targetOrigin = "*"
 ): Endpoint {
   return {


### PR DESCRIPTION
This is to fix runtime errors that occur when Comlink is used in a `Worklet` because `self` doesn't exist there.

I ran into a problem suddenly using Comlink in an `AudioWorklet` getting runtime errors [on line 425 because it's looking for the existence of a property on the `self` object](https://github.com/GoogleChromeLabs/comlink/blob/fd7330f7721182c068e988cea27370e72ca26d16/src/comlink.ts#L425)  -- since `self` isn't available in `Worklet`s I just replaced it with `globalThis` and it resolved the issue.

(The suddenness of it was just an unrelated tree-shaking issue -- if `expose` is optimized out by whatever bundler you're using then the `Worklet` never inspects `self`, and never crashes. It's possible that this issue could suddenly affect others if they change how they use Comlink in their projects, even without calling `expose`)