### PR TITLE
Harden exposed endpoints

### DIFF
--- a/tests/access.test.js
+++ b/tests/access.test.js
@@ -1,0 +1,174 @@
+import * as Comlink from "/base/dist/esm/comlink.mjs";
+
+describe("Comlink across workers with access control", function () {
+  async function init(worker, options) {
+    return new Promise(function (res) {
+      const onMessage = () => {
+        worker.removeEventListener("message", onMessage);
+        res();
+      };
+
+      worker.addEventListener("message", onMessage);
+
+      worker.postMessage(options);
+    });
+  }
+
+  beforeEach(async function () {
+    this.worker = new Worker("/base/tests/fixtures/restricted-worker.js");
+    this.init = (options) => init(this.worker, options);
+  });
+
+  afterEach(function () {
+    this.worker.terminate();
+  });
+
+  it("restricts access", async function () {
+    await this.init({ spec: {} });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    let error;
+    try {
+      await proxy.foo();
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.contain("undefined");
+  });
+
+  it("forbids calling non-functions", async function () {
+    await this.init({ spec: { foo: "primitive" } });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    let error;
+    try {
+      await proxy.foo();
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.contain("undefined");
+  });
+
+  it("forbids calling objects", async function () {
+    await this.init({ spec: { foo: {} } });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    let error;
+    try {
+      await proxy.foo();
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.contain("undefined");
+  });
+
+  it("allows invoking functions", async function () {
+    await this.init({ spec: { foo: "function" } });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    expect(await proxy.foo()).to.be.undefined;
+  });
+
+  it("can set fields", async function () {
+    await this.init({});
+
+    const proxy = Comlink.wrap(this.worker);
+
+    expect(await proxy.mycounter).to.equal(1);
+
+    await (proxy.mycounter = 10);
+
+    expect(await proxy.mycounter).to.equal(10);
+  });
+
+  it("can set primitive fields", async function () {
+    await this.init({ spec: { mycounter: "primitive" } });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    expect(await proxy.mycounter).to.equal(1);
+
+    await (proxy.mycounter = 10);
+
+    expect(await proxy.mycounter).to.equal(10);
+  });
+
+  it("can set fields of primitive fields", async function () {
+    await this.init({ spec: { myobj: "primitive" } });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    expect(await proxy.myobj).to.deep.equal({ value: 0 });
+
+    await (proxy.myobj.value = 10);
+
+    expect(await proxy.myobj).to.deep.equal({ value: 10 });
+  });
+
+  it("can restrict setting fields", async function () {
+    await this.init({ set: false });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    expect(await proxy.mycounter).to.equal(1);
+
+    await (proxy.mycounter = 10);
+
+    expect(await proxy.mycounter).to.equal(1);
+  });
+
+  it("can forbid setting on non-primitives", async function () {
+    await this.init({ spec: { mycounter: "function" } });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    await (proxy.mycounter = 10);
+
+    expect(await proxy.mycounter).to.equal(1);
+  });
+
+  it("can forbid setting on objects", async function () {
+    await this.init({ spec: { myobj: { value: "primitive" } } });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    await (proxy.myobj = 10);
+
+    expect(await proxy.myobj).to.deep.equal({ value: 0 });
+  });
+
+  it("can forbid constructing instances", async function () {
+    await this.init({ spec: { myclass: "function" } });
+
+    const proxy = Comlink.wrap(this.worker);
+
+    let error;
+
+    try {
+      await new proxy.myclass();
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error.message).to.contain("constructor");
+  });
+
+  it("creates new endpoint with same settings", async function () {
+    await this.init({ spec: { myobj: "primitive" } });
+
+    const proxy = Comlink.wrap(this.worker);
+    const clone = Comlink.wrap(await proxy[Comlink.createEndpoint]());
+
+    expect(await clone.myobj).to.deep.equal({ value: 0 });
+    expect(await clone.myclass).to.be.undefined;
+    expect(await clone.foo).to.be.undefined;
+    expect(await clone.mycounter).to.be.undefined;
+  });
+});

--- a/tests/fixtures/restricted-worker.js
+++ b/tests/fixtures/restricted-worker.js
@@ -1,0 +1,22 @@
+function onInit(event) {
+  self.removeEventListener("message", onInit);
+
+  importScripts("/base/dist/umd/comlink.js");
+
+  Comlink.expose(
+    {
+      foo() {},
+      mycounter: 1,
+      myobj: {
+        value: 0,
+      },
+      myclass: class {},
+    },
+    undefined,
+    event.data
+  );
+
+  self.postMessage({});
+}
+
+self.addEventListener("message", onInit);


### PR DESCRIPTION
:wave: Hi there! At Stackblitz we rely heavily on Comlink (as you might already be aware), and we're big fans, thanks for you work!

Recently, we've encountered a situation where one of our Comlink endpoints is not fully under our control (see [@webcontainer/api](https://www.npmjs.com/package/@webcontainer/api)). In this scenario, we would welcome some extra assurance that what we expose is exactly what we intend to, and nothing else. You could argue that Comlink, being about seamless RPC, might not 100% be the best fit for it, but we went ahead anyway because of its ergonomics :sweat_smile:

This patch is more or less what we've added to a internal fork for the purposes of "hardening" `Comlink.expose()`. It is somewhat nice b/c it only affects the "server" side endpoint, while the "client" endpoint does not need any new codepath.

I am not fully convinced this belongs in Comlink proper, but we wanted to show it to you anyway. We are actually considering moving this "hardening" to a external `Proxy` that wraps our exposed objects. One disadvantage of doing that is that, AFAICS, when Comlink traverses a `path` for a exposed object, we would need to create proxies on the fly.

:warning: This patch is adapted from something we built on top of Comlink 4.3.0, so it is not as thouroughly tested as it should be.

---

This adds `ExposeOptions` to `Comlink.expose()`. `options.spec` allows you to specify a "spec" of the object being exposed, a description of what the other side of the endpoint can do with the object. For instance, with the following spec:

```typescript
Comlink.expose(obj, ep, {
  spec: {
    walk: "function",
    bar: { jump: "function", name: "primitive" }
  }
});
```

the other side of the endpoint cannot perform certain actions:

```typescript
const obj = Comlink.wrap(ep);

// Allowed
obj.walk();
obj.bar.jump();
console.log(await obj.bar.name);

// Not allowed
obj.walk.toString();
obj.bar.jump.foo = 1;
await obj.bar.name.__proto__;
```