### PR TITLE
Make releaseProxy asynchronous

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -107,7 +107,7 @@ export type LocalObject<T> = { [P in keyof T]: LocalProperty<T[P]> };
  */
 export interface ProxyMethods {
   [createEndpoint]: () => Promise<MessagePort>;
-  [releaseProxy]: () => void;
+  [releaseProxy]: () => Promise<void>;
 }
 
 /**
@@ -455,9 +455,9 @@ function createProxy<T>(
     get(_target, prop) {
       throwIfProxyReleased(isProxyReleased);
       if (prop === releaseProxy) {
-        return () => {
+        return async () => {
           unregisterProxy(proxy);
-          releaseEndpoint(ep);
+          await releaseEndpoint(ep);
           isProxyReleased = true;
         };
       }


### PR DESCRIPTION
When I was using Deno with comlink, its testing framework was detecting that MessagePorts weren't being closed properly. In an earlier version of comlink, one could await a call to releaseProxy to ensure resources were properly disposed. It seems like this as been lost along the way with the latest changes.

Indeed the finalizers are a great addition but to make the tests clean, I still want to call releaseProxy accordingly when managing resources. In order for this to happen, releaseProxy needs to return a promise so it can be awaited upon.