### PR TITLE
Prevent endpoint from being closed when at least an object is exposed

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -295,6 +295,9 @@ export function expose(
   ep: Endpoint = globalThis as any,
   allowedOrigins: (string | RegExp)[] = ["*"]
 ) {
+  const newCount = (proxyCounter.get(ep) || 0) + 1;
+  proxyCounter.set(ep, newCount);
+
   ep.addEventListener("message", function callback(ev: MessageEvent) {
     if (!ev || !ev.data) {
       return;


### PR DESCRIPTION
This is a possible fix for #626. I wonder if we should return from `Comlink.expose` a function to deincrement that count again?