### PR TITLE
`requestResponseMessage` handlers optimization

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -597,9 +597,12 @@ function fromWireValue(value: WireValue): any {
 
 const messageResolvers = new Map();
 
-function handleMessage(event: MessageEvent) {
-    const { data } = event;
-    const resolver = data && messageResolvers.get(data.id);
+function handleMessage(ev: MessageEvent) {
+    const { data } = ev;
+    if (!data || !data.id) {
+      return;
+    }
+    const resolver = messageResolvers.get(data.id);
     if (resolver) {
         resolver(data);
         messageResolvers.delete(data.id);


### PR DESCRIPTION
As per #647, I followed josephrocca's advice.
Now there's one central function that assigns handlers from a map.
I wasn't 100% sure where to add/remove the event listeners, open for suggestions.

My tests showed a ~20% performance increase in a mass-messages scenario, YMMV.