### PR TITLE
`requestResponseMessage` handlers optimization

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -388,10 +388,12 @@ function isMessagePort(endpoint: Endpoint): endpoint is MessagePort {
 }
 
 function closeEndPoint(endpoint: Endpoint) {
+  endpoint.removeEventListener("message", handleMessage);
   if (isMessagePort(endpoint)) endpoint.close();
 }
 
 export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
+  ep.addEventListener("message", handleMessage);
   return createProxy<T>(ep, [], target) as any;
 }
 
@@ -593,25 +595,33 @@ function fromWireValue(value: WireValue): any {
   }
 }
 
+const messageResolvers: Map<string, (value: WireValue | PromiseLike<WireValue>) => void> = new Map();
+
+function handleMessage(ev: Event) {
+    const { data } = ev as MessageEvent;
+    if (!data || !data.id) {
+      return;
+    }
+    const resolver = messageResolvers.get(data.id);
+    if (resolver) {
+        resolver(data);
+        messageResolvers.delete(data.id);
+    }
+}
+
 function requestResponseMessage(
   ep: Endpoint,
   msg: Message,
   transfers?: Transferable[]
 ): Promise<WireValue> {
-  return new Promise((resolve) => {
-    const id = generateUUID();
-    ep.addEventListener("message", function l(ev: MessageEvent) {
-      if (!ev.data || !ev.data.id || ev.data.id !== id) {
-        return;
-      }
-      ep.removeEventListener("message", l as any);
-      resolve(ev.data);
-    } as any);
-    if (ep.start) {
-      ep.start();
-    }
-    ep.postMessage({ id, ...msg }, transfers);
-  });
+    return new Promise((resolve) => {
+        const id = generateUUID();
+        messageResolvers.set(id, resolve);
+        if (ep.start) {
+          ep.start();
+        }
+        ep.postMessage({ id, ...msg }, transfers);
+    });
 }
 
 function generateUUID(): string {


### PR DESCRIPTION
I initially opened it under #650 but then closed it after seeing @defunctzombie's #649 appearing 1 hour earlier (_what are the odds?!_). I then tested #649 and I fear that it does not improve performance, at least not against my tests.

My test (which is based on a real scenario I'm handling) sends approx ~125k messages in a very short period. When I try it with either vanilla or #649, it starts by handling some 1-2k messages and then grinds to a crawl, practically never finishing. My PR processes everything in ~25 seconds.

When loweing to ~72k messages, vanilla takes ~55 seconds to complete, #649 takes ~70 seconds, mine takes ~15 seconds.

-- ORIGINAL PR MSG--
As per #647, I followed @josephrocca's advice.
Now there's one central function that assigns handlers from a map.
I wasn't 100% sure where to add/remove the event listeners, open for suggestions.

My tests showed a ~20% performance increase in a mass-messages scenario, YMMV.