### PR TITLE
Use a single "message" event listener to dispatch received messages

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -404,12 +404,14 @@ export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
       return;
     }
     const resolver = pendingListeners.get(data.id);
-    if (resolver) {
-      try {
-        resolver(data);
-      } finally {
-        pendingListeners.delete(data.id);
-      }
+    if (!resolver) {
+      return;
+    }
+
+    try {
+      resolver(data);
+    } finally {
+      pendingListeners.delete(data.id);
     }
   });
 


### PR DESCRIPTION
From #649:

> We make heavy use of Comlink for our WebWorker communication. On some recent profiling traces I noticed a hot-path on the "addEventListener" line.
>
> <img width="678" alt="292389350-2052be72-8671-4e20-9e06-fef0a30cb420" src="https://github.com/GoogleChromeLabs/comlink/assets/9250155/06276f85-086f-4e4f-b1a9-ecaa07e38ceb">
>
> While its hard to say exactly how the event listeners are stored, most implementations I've seen for such interfaces involve storing them in an array and removing the listener equally requires adjusting an array. The existing logic also creates two closures - one for the Promise (which is unavoidable from what I can tell), and another for the event listener. As it was suggested in https://github.com/GoogleChromeLabs/comlink/issues/647 there is a potential for improvement by using a single "message" event listener and doing the dispatch manually by looking up the resolve functions in a Map.
>
> This definitely reduces the runtime cost of the requestResponseMessage call itself - though there's still cost to new Promise and the closure. There's a shifted cost to the ID lookup on the map though in my profiling that did not show up as a hot path item.
>
> Conceptually using a map for the lookup and one handler seems like it should perform better but if folks have some ideas on how to more robustly benchmark this PR that would be helpful.

This PR is similar to #649 and #651 but avoids that references to the resolve functions or the endpoint are kept in memory. 

The performance impact of this PR gets more noticeable the more parallel requests are made:
![boxcompare](https://github.com/GoogleChromeLabs/comlink/assets/9250155/0b0e5ab1-a25e-48e4-abb6-0b885169d0af)

See also https://github.com/GoogleChromeLabs/comlink/pull/651#issuecomment-1899065317


