### PR TITLE
fix: Safer check before calling start()

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -378,7 +378,7 @@ export function expose(
         ep.postMessage({ ...wireValue, id }, transferables);
       });
   } as any);
-  if (ep.start) {
+  if (typeof ep.start === "function") {
     ep.start();
   }
 }
@@ -607,7 +607,7 @@ function requestResponseMessage(
       ep.removeEventListener("message", l as any);
       resolve(ev.data);
     } as any);
-    if (ep.start) {
+    if (typeof ep.start === "function") {
       ep.start();
     }
     ep.postMessage({ id, ...msg }, transfers);


### PR DESCRIPTION
In both of these cases, the `ep` variable is the scope, and in some cases there'll be a `start()` method available, and we want to call it. I'm not sure exactly why - such a method doesn't show up in [GlobalWorkerScope](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope) but maybe it's somewhere else.

However, there might also just be a variable called `start` in your global scope, and it isn't a function, and Comlink will expect it to be callable. This PR compensates for that case by making sure that the value is a function before calling it.