### PR TITLE
Added requestWrap and sendReady

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -407,7 +407,7 @@ export function requestWrap<T>(ep: Endpoint, target?: any): Promise<Remote<T>> {
   })
 }
 
-export function sendReady(ep: Endpoint): void {
+export function sendReady(ep: Endpoint = globalThis as any): void {
   ep.postMessage({ status: "ready" });
 }
 


### PR DESCRIPTION
The user can await requestWrap until the Endpoint calls sendReady.

This is a proposed solution to the problems mentioned in #665 and #635.

It does not break the previous wrap or expose function signature but rather adds the two optional functions `requestWrap()` and `sendReady()` which can be used to avoid deadlocks.

Here is an example on how to use the proposed changes in actual code:
`main.ts`
```typescript
import * as Comlink from "comlink";

let worker = new Worker(new URL("./extension", import.meta.url), { type: "module" });
let api = await Comlink.requestWrap(worker);

await api.hey();
```

`extension.ts`
```typescript
import * as Comlink from "comlink";

Comlink.expose(
  {
    str: "exposed string",
    hey() { console.log("helloo!") },
  });

Comlink.sendReady(self);
```
