### PR TITLE
Fix message ports not being closed when proxy is relased

### DIFF
--- a/tests/node/main.mjs
+++ b/tests/node/main.mjs
@@ -24,5 +24,17 @@ describe("node", () => {
       const otherProxy = Comlink.wrap(otherEp);
       expect(await otherProxy(20, 1)).to.equal(21);
     });
+
+    it("releaseProxy closes MessagePort created by createEndpoint", async function () {
+      const proxy = Comlink.wrap(nodeEndpoint(this.worker));
+      const otherEp = await proxy[Comlink.createEndpoint]();
+      const otherProxy = Comlink.wrap(otherEp);
+      expect(await otherProxy(20, 1)).to.equal(21);
+
+      await new Promise((resolve) => {
+        otherEp.close = resolve; // Resolve the promise when the MessagePort is closed.
+        otherProxy[Comlink.releaseProxy](); // Release the proxy, which should close the MessagePort.
+      });
+    });
   });
 });

--- a/tests/worker.comlink.test.js
+++ b/tests/worker.comlink.test.js
@@ -33,4 +33,16 @@ describe("Comlink across workers", function () {
     const otherProxy = Comlink.wrap(otherEp);
     expect(await otherProxy(20, 1)).to.equal(21);
   });
+
+  it("releaseProxy closes MessagePort created by createEndpoint", async function () {
+    const proxy = Comlink.wrap(this.worker);
+    const otherEp = await proxy[Comlink.createEndpoint]();
+    const otherProxy = Comlink.wrap(otherEp);
+    expect(await otherProxy(20, 1)).to.equal(21);
+
+    await new Promise((resolve) => {
+      otherEp.close = resolve; // Resolve the promise when the MessagePort is closed.
+      otherProxy[Comlink.releaseProxy](); // Release the proxy, which should close the MessagePort.
+    });
+  });
 });


### PR DESCRIPTION
Fixes a regression that was introduced in #653 in that releasing a proxy would not close the underlying message port endpoints. The reason for this was that [`requestResponseMessage` was called with a new Map](https://github.com/GoogleChromeLabs/comlink/blob/fd4b52666b1ec62784f8b45cb1108c7e40bc481d/src/comlink.ts#L428-L430), causing the returned promise to never settle and preventing `closeEndpoint(ep)` from being called. 

This PR fixes this by making sure that we always pass the endpoint's pending listeners to the `requestResponseMessage` function. Both the endpoint and its pending listeners are now passed as a single object to all relevant functions to reflect the tight coupling between those.