### PR TITLE
Fix Proxy.set type assertion

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -511,8 +511,6 @@ function createProxy<T>(
     },
     set(_target, prop, rawValue) {
       throwIfProxyReleased(isProxyReleased);
-      // FIXME: ES6 Proxy Handler `set` methods are supposed to return a
-      // boolean. To show good will, we return true asynchronously ¯\_(ツ)_/¯
       const [value, transferables] = toWireValue(rawValue);
       return requestResponseMessage(
         epWithPendingListeners,
@@ -522,7 +520,7 @@ function createProxy<T>(
           value,
         },
         transferables
-      ).then(fromWireValue) as any;
+      ).then(fromWireValue) as unknown as true;
     },
     apply(_target, _thisArg, rawArgumentList) {
       throwIfProxyReleased(isProxyReleased);


### PR DESCRIPTION
TIL: This is a TypeScript quirk. There's actually no need to return a literal boolean value for Proxy set methods, they've always been coerced.
https://262.ecma-international.org/6.0/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver

A Promise is returned, so this will of course always evaluate to true.