### PR TITLE
Support workers in all major runtimes out of the box

### DIFF
--- a/docs/examples/06-node-example/main.mjs
+++ b/docs/examples/06-node-example/main.mjs
@@ -1,11 +1,7 @@
-import { Worker } from "worker_threads";
-import * as Comlink from "../../../dist/esm/comlink.mjs";
-import nodeEndpoint from "../../../dist/esm/node-adapter.mjs";
+import { Worker as NodeWorker } from "node:worker_threads";
+import { wrap } from "../../../dist/esm/comlink.mjs";
 
-async function init() {
-  const worker = new Worker("./worker.mjs");
+const worker = new NodeWorker(new URL(import.meta.resolve("./worker.mjs")));
 
-  const api = Comlink.wrap(nodeEndpoint(worker));
-  console.log(await api.doMath());
-}
-init();
+const api = wrap(worker);
+console.log(await api.add(6, 7));

--- a/docs/examples/08-portable-worker/index.html
+++ b/docs/examples/08-portable-worker/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="./main.mjs" type="module"></script>

--- a/docs/examples/08-portable-worker/main.mjs
+++ b/docs/examples/08-portable-worker/main.mjs
@@ -1,0 +1,14 @@
+// import { wrap } from "https://unpkg.com/comlink@alpha/dist/esm/comlink.mjs";
+import { wrap } from "../../../dist/esm/comlink.mjs";
+import { PortableWorker } from "./portable-worker.mjs";
+
+const worker = new PortableWorker(import.meta.resolve("./worker.mjs"));
+const api = wrap(worker);
+
+// Single call
+console.log(await api.add(6, 7));
+
+// Interleaved calls
+console.log(
+  await Promise.all([api.add(4, 5), api.add(6, 7), api.add(100, -5)])
+);

--- a/docs/examples/08-portable-worker/portable-worker.d.ts
+++ b/docs/examples/08-portable-worker/portable-worker.d.ts
@@ -1,0 +1,15 @@
+import type { Worker as NodeWorker } from "node:worker_threads";
+
+type WorkerConstructorOptions = (ConstructorParameters<
+  typeof globalThis.Worker
+> &
+  ConstructorParameters<typeof NodeWorker>)[1];
+
+interface PortableWorkerConstructor {
+  new (
+    url: string | URL,
+    workerOptions?: Omit<WorkerConstructorOptions, "type">
+  ): Worker | NodeWorker;
+}
+
+export const PortableWorker: PortableWorkerConstructor;

--- a/docs/examples/08-portable-worker/portable-worker.mjs
+++ b/docs/examples/08-portable-worker/portable-worker.mjs
@@ -1,0 +1,89 @@
+// import { wrap } from "https://unpkg.com/comlink@alpha/dist/esm/comlink.mjs";
+import { wrap } from "../../../dist/esm/comlink.mjs";
+
+function isCrossOrigin(url) {
+  if (!globalThis.location) {
+    return false;
+  }
+  const scriptOrigin = globalThis.location.origin;
+  const workerOrigin = new URL(url, globalThis.location.href).origin;
+  return scriptOrigin !== workerOrigin;
+}
+
+function constructPortableWebWorker(url, workerOptions) {
+  const useTrampoline = isCrossOrigin(url);
+
+  // We could use the trampoline unconditionally, but this would require adding
+  // `blob:` to the CSP unnecessarily. So we avoid it when possible.
+  if (useTrampoline) {
+    // Needed until something like
+    // https://github.com/lgarron/worker-execution-origin or
+    // https://github.com/whatwg/html/issues/6911 is available in all browser.
+    const trampolineSource = `import ${JSON.stringify(url.toString())};`;
+    const blob = new Blob([trampolineSource], {
+      type: "text/javascript",
+    });
+
+    url = URL.createObjectURL(blob);
+  }
+
+  const worker = new globalThis.Worker(url, {
+    ...workerOptions,
+    type: "module",
+  });
+
+  if (useTrampoline) {
+    const originalTerminate = worker.terminate.bind(worker);
+    Object.defineProperty(worker, "terminate", {
+      get() {
+        URL.revokeObjectURL(url);
+        originalTerminate();
+      },
+    });
+  }
+
+  return worker;
+}
+
+function constructNodeStyleWorker(url, workerOptions) {
+  // We could theoretically use dynamic import, but:
+  //
+  // - 1. There is no synchronous way to do this conditionally. We can't do it
+  //      synchronously in a constructor, and while top-level `await` is
+  //      well-supported in runtimes it's not as easy to use with bundlers.
+  // 2.  `.getBuiltinModule(…)` signals more clearly that these are strictly
+  //      runtime dependencies.
+  const { Worker: NodeWorker } = globalThis.process.getBuiltinModule(
+    "node:worker_threads"
+  );
+
+  // `import.meta.resolve(…)` is the recommended way to get the path to a
+  // relative file to pass to the worker constructor. This returns a `file://…`
+  // URL as a string, which `bun` and `deno` accept for the worker constructor
+  // but `node` does not. We can detect this and convert it to a `URL` to allow
+  // more concise, idiomatic code across all platforms.
+  url =
+    typeof url === "string" && url.startsWith("file://") ? new URL(url) : url;
+
+  return new NodeWorker(url, workerOptions);
+}
+
+export function PortableWorker(url, workerOptions) {
+  const hasWebWorkers = globalThis.Worker;
+  const hasBuiltinModules = globalThis.process?.getBuiltinModule;
+
+  if (hasWebWorkers && !hasBuiltinModules) {
+    // Browsers
+    return constructPortableWebWorker(url, workerOptions);
+  }
+
+  const webWorkersHaveUnref = globalThis.Worker?.prototype.unref;
+
+  if (hasWebWorkers && hasBuiltinModules && webWorkersHaveUnref) {
+    // `bun`
+    return constructPortableWebWorker(url, workerOptions);
+  } else {
+    // `node` and `deno`
+    return constructNodeStyleWorker(url, workerOptions);
+  }
+}

--- a/docs/examples/08-portable-worker/worker.mjs
+++ b/docs/examples/08-portable-worker/worker.mjs
@@ -1,9 +1,10 @@
 // import { expose } from "https://unpkg.com/comlink@alpha/dist/esm/comlink.mjs";
 import { expose } from "../../../dist/esm/comlink.mjs";
 
-const api = {
+export const api = {
   add(a, b) {
     return a + b;
   },
 };
+
 expose(api);

--- a/package.json
+++ b/package.json
@@ -2,17 +2,21 @@
   "name": "comlink",
   "version": "4.4.2",
   "description": "Comlink makes WebWorkers enjoyable",
-  "main": "dist/umd/comlink.js",
-  "module": "dist/esm/comlink.mjs",
-  "types": "dist/umd/comlink.d.ts",
+  "main": "./dist/umd/comlink.js",
+  "module": "./dist/esm/comlink.mjs",
+  "types": "./dist/umd/comlink.d.ts",
   "sideEffects": false,
   "scripts": {
     "build": "rollup -c",
     "test:unit": "karma start",
     "test:node": "mocha ./tests/node/main.mjs",
+    "test:portability": "npm run test:portability:node && npm run test:portability:bun && npm run test:portability:deno",
+    "test:portability:node": "./tests/portability/test.bash node --",
+    "test:portability:bun": "./tests/portability/test.bash npx -- bun run --",
+    "test:portability:deno": "./tests/portability/test.bash npx -- deno run --allow-read --",
     "test:types": "tsc -p ./tests/tsconfig.json",
     "test:types:watch": "npm run test:types -- --watch",
-    "test": "npm run fmt_test && npm run build && npm run test:types && npm run test:unit && npm run test:node",
+    "test": "npm run fmt_test && npm run build && npm run test:types && npm run test:unit && npm run test:node && npm run test:portability",
     "fmt": "prettier --write './*.{mjs,js,ts,md,json,html}' './{src,docs,tests}/{,**/}*.{mjs,js,ts,md,json,html}'",
     "fmt_test": "test $(prettier -l './*.{mjs,js,ts,md,json,html}' './{src,docs,tests}/{**/,}*.{mjs,js,ts,md,json,html}' | wc -l) -eq 0",
     "watchtest": "CHROME_ONLY=1 karma start --no-single-run"
@@ -29,8 +33,10 @@
   "devDependencies": {
     "@rollup/plugin-terser": "0.4.0",
     "@rollup/plugin-typescript": "11.0.0",
+    "bun": "1.3.6",
     "chai": "^4.3.7",
     "conditional-type-checks": "1.0.6",
+    "deno": "2.6.5",
     "husky": "8.0.3",
     "karma": "6.4.1",
     "karma-chai": "0.1.0",
@@ -45,6 +51,27 @@
     "rimraf": "4.1.2",
     "rollup": "3.10.1",
     "tslib": "2.4.1",
-    "typescript": "4.9.4"
+    "typescript": "5.9.3"
+  },
+  "files": [
+    "./dist/",
+    "./docs/",
+    "./src/"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/umd/comlink.d.ts",
+      "import": "./dist/esm/comlink.mjs",
+      "require": "./dist/umd/comlink.js"
+    },
+    "./node-adapter": {
+      "types": "./dist/umd/node-adapter.d.ts",
+      "import": "./dist/esm/node-adapter.mjs",
+      "require": "./dist/umd/node-adapter.js"
+    },
+    "./examples/portable-worker": {
+      "types": "./docs/examples/08-portable-worker/portable-worker.d.ts",
+      "import": "./docs/examples/08-portable-worker/portable-worker.mjs"
+    }
   }
 }

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -22,6 +22,8 @@ export const finalizer = Symbol("Comlink.finalizer");
 
 const throwMarker = Symbol("Comlink.thrown");
 
+const REF_COUNT_BY_DEFAULT = true;
+
 /**
  * Interface of values that were marked to be proxied with `comlink.proxy()`.
  * Can also be implemented by classes.
@@ -283,6 +285,86 @@ export const transferHandlers = new Map<
   ["throw", throwTransferHandler],
 ]);
 
+export interface NodeEndpoint {
+  postMessage(message: any, transfer?: any[]): void;
+  on(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: {}
+  ): void;
+  off(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: {}
+  ): void;
+  ref?: () => void;
+  unref?: () => void;
+  start?: () => void;
+  terminate?: () => void;
+  close?: () => void;
+}
+
+export function nodeEndpoint(rawEndpoint: NodeEndpoint): Endpoint {
+  const listeners: {
+    [event: string]:
+      | WeakMap<EventListenerOrEventListenerObject, any>
+      | undefined;
+  } = {};
+  function removeEventListener(
+    event: "message",
+    eh: EventListenerOrEventListenerObject
+  ) {
+    const l = listeners[event]?.get(eh);
+    if (!l) {
+      return;
+    }
+    rawEndpoint.off(event, l);
+    listeners[event]?.delete(eh);
+  }
+
+  return {
+    postMessage: rawEndpoint.postMessage.bind(rawEndpoint) as any,
+    addEventListener: (
+      event: "message",
+      handler,
+      options?: { once: boolean }
+    ) => {
+      const listener = (data: any) => {
+        if (options?.once) {
+          removeEventListener(event, listener);
+        }
+        if ("handleEvent" in handler) {
+          handler.handleEvent({ data } as MessageEvent);
+        } else {
+          handler({ data } as MessageEvent);
+        }
+      };
+      rawEndpoint.on(event, listener);
+      (listeners[event] ?? new WeakMap()).set(handler, listener);
+    },
+    removeEventListener,
+    // In theory, `node` exposes these on `Symbol.for('nodejs.ref') ` and
+    // `Symbol.for('nodejs.unref') ` fields. In practice, this is not supported across all runtimes.
+    ref: rawEndpoint.ref?.bind(rawEndpoint),
+    unref: rawEndpoint.unref?.bind(rawEndpoint),
+    start: (rawEndpoint as { start?: () => void }).start?.bind(rawEndpoint),
+    terminate: (rawEndpoint as { terminate?: () => void }).terminate?.bind(
+      rawEndpoint
+    ),
+    close: (rawEndpoint as { close?: () => void }).close?.bind(rawEndpoint),
+  };
+}
+
+function toEndpoint(endpoint: Endpoint | NodeEndpoint): Endpoint {
+  if (
+    !("addEventListener" in endpoint) ||
+    !("removeEventListener" in endpoint)
+  ) {
+    return nodeEndpoint(endpoint);
+  }
+  return endpoint;
+}
+
 function isAllowedOrigin(
   allowedOrigins: (string | RegExp)[],
   origin: string
@@ -298,11 +380,19 @@ function isAllowedOrigin(
   return false;
 }
 
+function defaultExposeEndpoint() {
+  return (
+    globalThis.process?.getBuiltinModule("node:worker_threads").parentPort ??
+    (globalThis as Endpoint)
+  );
+}
+
 export function expose(
   obj: any,
-  ep: Endpoint = globalThis as any,
+  endpoint: Endpoint | NodeEndpoint = defaultExposeEndpoint(),
   allowedOrigins: (string | RegExp)[] = ["*"]
 ) {
+  const ep = toEndpoint(endpoint);
   ep.addEventListener("message", function callback(ev: MessageEvent) {
     if (!ev || !ev.data) {
       return;
@@ -369,7 +459,7 @@ export function expose(
         const [wireValue, transferables] = toWireValue(returnValue);
         ep.postMessage({ ...wireValue, id }, transferables);
         if (type === MessageType.RELEASE) {
-          // detach and deactive after sending release response above.
+          // detach and deactivate after sending release response above.
           ep.removeEventListener("message", callback as any);
           closeEndPoint(ep);
           if (finalizer in obj && typeof obj[finalizer] === "function") {
@@ -386,21 +476,37 @@ export function expose(
         ep.postMessage({ ...wireValue, id }, transferables);
       });
   } as any);
-  if (ep.start) {
-    ep.start();
-  }
-}
-
-function isMessagePort(endpoint: Endpoint): endpoint is MessagePort {
-  return endpoint.constructor.name === "MessagePort";
+  ep.start?.();
 }
 
 function closeEndPoint(endpoint: Endpoint) {
-  if (isMessagePort(endpoint)) endpoint.close();
+  endpoint.close?.();
+  endpoint.terminate?.();
 }
 
-export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
-  const pendingListeners : PendingListenersMap = new Map();
+/**
+ * In certain runtimes like `node`, communicating with a worker will effectively
+ * call `.ref()` on (i.e."reference") the worker, which means that the worker
+ * will keep the process from terminating by default (similar to an unresolved
+ * `Promise`). It is possible to call `.unref()` on a worker to prevent this,
+ * but that may allows process to exit before all the intended work is
+ * completed.
+ *
+ * When wrapping a `node` worker, `comlink` now automatically tracks wrapped
+ * calls, and calls `.unref()` on the worker whenever there are no more pending
+ * calls. This is usually what you want if you are using the the worker
+ * specifically for a wrapped API and nothing else. If you need manually manage
+ * the worker or pass messages outside of `comlink`, pass `{ refCount: false }`
+ * for `options` to disable this behaviour. Note that this makes no difference
+ * for workers in web browsers.
+ */
+export function wrap<T>(
+  endpoint: Endpoint | NodeEndpoint,
+  target?: any,
+  options?: { refCount: boolean }
+): Remote<T> {
+  const ep = toEndpoint(endpoint);
+  const pendingListeners: PendingListenersMap = new Map();
 
   ep.addEventListener("message", function handleMessage(ev: Event) {
     const { data } = ev as MessageEvent;
@@ -416,6 +522,38 @@ export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
       resolver(data);
     } finally {
       pendingListeners.delete(data.id);
+      if (
+        pendingListeners.size === 0 &&
+        (options?.refCount ?? REF_COUNT_BY_DEFAULT)
+      ) {
+        /**
+         * `deno` seems to have a bug here: https://github.com/denoland/deno/issues/31871
+         * 
+         * https://docs.deno.com/api/node/worker_threads/~/Worker#method_unref_0
+         * states:
+         *
+         * > Calling `unref()` on a worker allows the thread to exit if this
+         * > is the only active handle in the event system. If the worker is
+         * > already `unref()`ed calling `unref()` again has no effect.
+         *
+         * And yet calling `.unref()` here doesn't allow the process to exit.
+         * Even two times is not enough. It doesn't seem to work unless we
+         * Beetlejuice it (i.e. call it three times). 🤷
+         *
+         * Now:
+         *
+         * - There is no way to check if the first call suceeded.
+         * - It would be nice to avoid runtime sniffing in library code.
+         * - Calling it additional times doesn't have an effect in other
+         *   runtimes.
+         * - The calls are *relatively* fast.
+         *
+         * So we call it three times unconditionally (instead of once).
+         */
+        ep.unref?.();
+        ep.unref?.();
+        ep.unref?.();
+      }
     }
   });
 
@@ -639,11 +777,10 @@ function requestResponseMessage(
   return new Promise((resolve) => {
     const id = generateUUID();
     pendingListeners.set(id, resolve);
-    if (ep.start) {
-      ep.start();
-    }
+    ep.start?.();
+    ep.ref?.();
     ep.postMessage({ id, ...msg }, transfers);
-});
+  });
 }
 
 function generateUUID(): string {

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -275,6 +275,41 @@ const throwTransferHandler: TransferHandler<
 };
 
 /**
+ * `deno` seems to have a bug: https://github.com/denoland/deno/issues/31871
+ *
+ * https://docs.deno.com/api/node/worker_threads/~/Worker#method_unref_0 states:
+ *
+ * > Calling `unref()` on a worker allows the thread to exit if this is the only
+ * > active handle in the event system. If the worker is already `unref()`ed
+ * > calling `unref()` again has no effect.
+ *
+ * And yet calling `.unref()` here doesn't allow the process to exit. Even two
+ * times is not enough. It seems to take at least 5 times, in some cases.
+ *
+ * Now:
+ *
+ * - There is no way to check if the first call suceeded.
+ * - It would be nice to avoid runtime sniffing in library code.
+ * - Calling it additional times doesn't have an effect in other runtimes.
+ * - The calls are *relatively* fast — on the order of a few nanoseconds in all runtimes.
+ *
+ * So we call it five times unconditionally (instead of once).
+ */
+function unrefWorkaround(reffable: {
+  unref?: () => void;
+}): (() => void) | undefined {
+  const unref = reffable.unref?.bind(reffable);
+  if (!unref) {
+    return;
+  }
+  return () => {
+    for (let i = 0; i < 5; i++) {
+      unref();
+    }
+  };
+}
+
+/**
  * Allows customizing the serialization of certain values.
  */
 export const transferHandlers = new Map<
@@ -346,7 +381,7 @@ export function nodeEndpoint(rawEndpoint: NodeEndpoint): Endpoint {
     // In theory, `node` exposes these on `Symbol.for('nodejs.ref') ` and
     // `Symbol.for('nodejs.unref') ` fields. In practice, this is not supported across all runtimes.
     ref: rawEndpoint.ref?.bind(rawEndpoint),
-    unref: rawEndpoint.unref?.bind(rawEndpoint),
+    unref: unrefWorkaround(rawEndpoint),
     start: (rawEndpoint as { start?: () => void }).start?.bind(rawEndpoint),
     terminate: (rawEndpoint as { terminate?: () => void }).terminate?.bind(
       rawEndpoint
@@ -526,32 +561,6 @@ export function wrap<T>(
         pendingListeners.size === 0 &&
         (options?.refCount ?? REF_COUNT_BY_DEFAULT)
       ) {
-        /**
-         * `deno` seems to have a bug here: https://github.com/denoland/deno/issues/31871
-         * 
-         * https://docs.deno.com/api/node/worker_threads/~/Worker#method_unref_0
-         * states:
-         *
-         * > Calling `unref()` on a worker allows the thread to exit if this
-         * > is the only active handle in the event system. If the worker is
-         * > already `unref()`ed calling `unref()` again has no effect.
-         *
-         * And yet calling `.unref()` here doesn't allow the process to exit.
-         * Even two times is not enough. It doesn't seem to work unless we
-         * Beetlejuice it (i.e. call it three times). 🤷
-         *
-         * Now:
-         *
-         * - There is no way to check if the first call suceeded.
-         * - It would be nice to avoid runtime sniffing in library code.
-         * - Calling it additional times doesn't have an effect in other
-         *   runtimes.
-         * - The calls are *relatively* fast.
-         *
-         * So we call it three times unconditionally (instead of once).
-         */
-        ep.unref?.();
-        ep.unref?.();
         ep.unref?.();
       }
     }

--- a/src/node-adapter.ts
+++ b/src/node-adapter.ts
@@ -5,45 +5,16 @@
  */
 
 import { Endpoint } from "./protocol";
+import { nodeEndpoint as comlinkNodeEndpoint, NodeEndpoint } from "./comlink";
 
-export interface NodeEndpoint {
-  postMessage(message: any, transfer?: any[]): void;
-  on(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: {}
-  ): void;
-  off(
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: {}
-  ): void;
-  start?: () => void;
-}
+let warned = false;
 
-export default function nodeEndpoint(nep: NodeEndpoint): Endpoint {
-  const listeners = new WeakMap();
-  return {
-    postMessage: nep.postMessage.bind(nep),
-    addEventListener: (_, eh) => {
-      const l = (data: any) => {
-        if ("handleEvent" in eh) {
-          eh.handleEvent({ data } as MessageEvent);
-        } else {
-          eh({ data } as MessageEvent);
-        }
-      };
-      nep.on("message", l);
-      listeners.set(eh, l);
-    },
-    removeEventListener: (_, eh) => {
-      const l = listeners.get(eh);
-      if (!l) {
-        return;
-      }
-      nep.off("message", l);
-      listeners.delete(eh);
-    },
-    start: nep.start && nep.start.bind(nep),
-  };
+export default function nodeEndpoint(rawEndpoint: NodeEndpoint): Endpoint {
+  if (warned) {
+    console.warn(
+      "It is no longer necessary to call `nodeAdapter(…)` unless you want to call the `.addEventListener(…)` / `.removeEventListener(…)` API yourself. If you need this, `nodeEndpoint(…)` is now exported from the main `comlink` module — import from there to avoid duplicated code and avoid this warning."
+    );
+    warned = true;
+  }
+  return comlinkNodeEndpoint(rawEndpoint);
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -27,9 +27,12 @@ export interface PostMessageWithOrigin {
 }
 
 export interface Endpoint extends EventSource {
-  postMessage(message: any, transfer?: Transferable[]): void;
-
+  postMessage(message: any, transfer?: readonly Transferable[]): void;
+  ref?: () => void;
+  unref?: () => void;
   start?: () => void;
+  terminate?: () => void;
+  close?: () => void;
 }
 
 export const enum WireValueType {

--- a/tests/portability/main.mjs
+++ b/tests/portability/main.mjs
@@ -1,0 +1,23 @@
+import { Worker as NodeWorker } from "node:worker_threads";
+import { wrap } from "../../dist/esm/comlink.mjs";
+import assert from "node:assert";
+
+const worker = new NodeWorker(new URL(import.meta.resolve("./worker.mjs")));
+const api = wrap(worker);
+
+// Single call
+assert.equal(await api.add(6, 7), 13);
+
+// Interleaved calls
+assert.deepEqual(
+  await Promise.all([api.add(4, 5), api.add(6, 7), api.add(100, -5)]),
+  [9, 13, 95]
+);
+
+// This tests passes if the process gets to this point without hanging and then
+// exits successfully.
+//
+// If this test fails due to broken reference counting, it could exit early and
+// the `assert(…)` calls are meaningless. So we provide a "successfully finished" message we can
+// grep for, to make sure we reached here.
+console.log("successfully finished");

--- a/tests/portability/refCount-false.mjs
+++ b/tests/portability/refCount-false.mjs
@@ -1,0 +1,42 @@
+import { Worker as NodeWorker } from "node:worker_threads";
+import { wrap } from "../../dist/esm/comlink.mjs";
+import assert from "node:assert";
+
+// This is neeeded to call `.unref()` on the timer for `deno` (so that we can
+// test only that the worker is the one hanging the process).
+import { setTimeout } from "node:timers";
+
+const worker = new NodeWorker(new URL(import.meta.resolve("./worker.mjs")));
+const api = wrap(worker, undefined, { refCount: false });
+
+let reachedEnd = false;
+
+const timeout = setTimeout(() => {
+  assert.ok(reachedEnd);
+  // This tests passes if the process hangs and gets caught by this (unreffed) timeout.
+  //
+  // We provide a "successfully timed out" message we can grep for, to make sure we reached here.
+  console.log("successfully timed out");
+
+  // This should exit the process successfully…
+  worker.unref();
+  // … but `deno` seems to need at least 4 more tries on some systems. 🤷
+  // https://github.com/denoland/deno/issues/31871
+  if ("Deno" in globalThis) {
+    for (let i = 0; i < 4; i++) {
+      worker.unref();
+    }
+  }
+}, 100);
+timeout.unref();
+
+// Single call
+assert.equal(await api.add(6, 7), 13);
+
+// Parallelized calls
+assert.deepEqual(
+  await Promise.all([api.add(4, 5), api.add(6, 7), api.add(100, -5)]),
+  [9, 13, 95]
+);
+
+reachedEnd = true;

--- a/tests/portability/test.bash
+++ b/tests/portability/test.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env -S bash --
+
+set -euo pipefail
+set -x
+
+# Change dirs so that the printed commands can be run from the project root.
+cd "$(dirname "${0}")/../../"
+
+"${@}" ./tests/portability/main.mjs | grep 'successfully finished'
+"${@}" ./tests/portability/refCount-false.mjs | grep 'successfully timed out'
+"${@}" ./docs/examples/06-node-example/main.mjs
+"${@}" ./docs/examples/08-portable-worker/main.mjs

--- a/tests/portability/worker.mjs
+++ b/tests/portability/worker.mjs
@@ -1,0 +1,9 @@
+import { expose } from "../../dist/esm/comlink.mjs";
+
+const api = {
+  add(a, b) {
+    return a + b;
+  },
+};
+
+expose(api);


### PR DESCRIPTION
This PR includes all the logic necessary to write portable workers, making it trivial to write code that can be used in all browsers and all major runtimes.

With this implementation, the following now works in `node`, `bun`, and `deno`:

```ts
// main.js
import { Worker as NodeWorker } from "node:worker_threads";
import { wrap } from "comlink";

const api = wrap(new NodeWorker(new URL(import.meta.resolve("./worker.js"))));
console.log(await api.add(6, 7));
```

```ts
// worker.js
import { expose } from "comlink";

expose({ add: (a, b) => a + b });
```

And the following works in all major browsers (in addition to `node`, `bun`, and `deno`):

```ts
// main.js
import { PortableWorker } from "comlink/examples/portable-worker";
import { wrap } from "comlink";

const api = wrap(new PortableWorker(import.meta.resolve("./worker.js")));
console.log(await api.add(6, 7));
```

This PR makes the following changes:
# Automatic `nodeEndpoint(…)` for workers

`expose(…)` and `wrap(…)` accept `node` workers as arguments and automatically wrap them by looking for an endpoint that looks an `EventEmitter` (has `.addListener()`)  but not an `EventTarget`  (has `.addEventListener()`). I believe I told @surma a long time ago I would send a PR for this. So here we go. 😁

This means `nodeEndpoint(…)` is no longer needed by default. However:

- `comlink` has not defined historically defined exports and provided files that can be (and are probably) used standalone by other projects. So we need to preserve the existing files and their APIs to avoid any risk of breakage, without any cross-imports in the build.
- Some projects may be relying on being able to call `addEventListener(…)` / `removeEventListener(…)` on the `nodeEndpoint(…)` output.

Therefore:

- Builds of `comlink.ts` now include the `nodeEndpoint(…)` implementation, so that these files can remain standalone.
- Builds of `comlink.ts` now *export* `nodeEndpoint` so that users can call this if needed, without code duplication.
- Duplicate implementations are still provided in the `node-adapter.ts` builds, albeit with a warning.

Note that the code seems to have previously been written under the assumption that `node` message ports do not satisfy the `Endpoint` interface, but at least as of 2026 they do. This means that `node` message ports are not singled out in the type signatures of `wrap(…)` and `expose(…)` like they were in `nodeEndpoint(…)`.

# Automatic `.unref()`

When using reffable workers (or other reffable endpoints), `wrap(…)` now uses pending requests to perform reference counting on the worker and calls `.unref(…)` when it is not waiting on the worker. For anyone who is familiar with web worker behaviour, this should do "the right thing" out of the box.

It solves the following issue: `node`-style workers automatically `.ref()` when a message is passed, which means that the process will hang by default. It is possible to prevent this by calling `.unref()` but this can allow the process to exit before all work is completed, unless the caller is very careful to track pending requests. (The caller can also call `.terminate()` on the worker or `exit(…)` on the process, but these tend to be heavy tools that can mask other issues.) Since `comlink` has a centralized place that can track these requests `wrap(…)`, it can make this easy. 

`wrap(…)` now accepts an `options` argument which takes `{ refCount: false }` to opt out of this behaviour.

## Examples

- `06-node-example` has been updated so that it works when run from any working directory in any runtime.
- `08-portable-worker` includes an example of how to instantiate a worker cross-platform (`node`, `bun`, `deno`, and all modern browsers). This handles:
	- Feature detection so that web workers are used when possible, and `node`-style workers when needed. Note that this is extra-subtle because `bun`  and `deno` both support web workers but the latter only supports the reffable API on `node:worker_threads` workers.
	- Instantiating a cross-origin trampoline that is needed when the worker code is not on the same origin as the main page.
	- Accepting strings starting with `file://` so that a return value of [`import.meta.resolve(…)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve) can be passed to the constructor directly.

# `package.json` fixups

I added `files` and `exports` to `package.json`. I found it difficult to test the package without these.
# Runtime testing

- `bun` and `deno` are installed as dev dependencies and used to test compatibility.

There are also a few more details based on over a decade of experience with web workers. However, I've tried to stay idiomatic to the existing codebase where possible (even if there are a lot of opportunities to modernize).
