### PR TITLE
fix: replace Math.random() with crypto.randomUUID() in generateUUID()

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -647,8 +647,5 @@ function requestResponseMessage(
 }
 
 function generateUUID(): string {
-  return new Array(4)
-    .fill(0)
-    .map(() => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16))
-    .join("-");
+  return crypto.randomUUID();
 }


### PR DESCRIPTION
## Problem

`generateUUID()` uses `Math.random()` to produce message correlation IDs:

```typescript
function generateUUID(): string {
  return new Array(4)
    .fill(0)
    .map(() => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16))
    .join("-");
}
```

Two issues:
1. **Not cryptographically random** — `Math.random()` is a PRNG, not a CSPRNG. While these IDs never leave the browser, using `Math.random()` for ID generation is a code quality issue that static analysis tools flag.
2. **Not valid UUIDs** — the function is named `generateUUID()` but produces `hex-hex-hex-hex` strings that don't conform to RFC 4122.

## Fix

```typescript
function generateUUID(): string {
  return crypto.randomUUID();
}
```

`crypto.randomUUID()` is available in all environments where comlink runs:
- Browsers: Chrome 92+, Firefox 95+, Safari 15.4+ (July 2021+)
- Web Workers: same as main thread
- Service Workers: same as main thread
- Node.js: global `crypto.randomUUID()` available since Node.js 19

## Testing

No test changes needed — this is a drop-in replacement with identical semantics for the callers. The ID is only used as a `pendingListeners` map key within the same process.