### PR TITLE
fix: Defer endpoint release while requests are in flight

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,17 +44,15 @@ module.exports = function (config) {
         if (process.env.INSIDE_DOCKER) {
           return ["DockerChrome"];
         } else if (process.env.CHROME_ONLY) {
-          return ["ChromeHeadlessGC"];
+          return ["ChromeHeadless"];
         } else {
           // Filtering SafariTechPreview because I am having
           // local issues and I have no idea how to fix them.
           // I know that’s not a good reason to disable tests,
           // but Safari TP is relatively unimportant.
-          return availableBrowsers
-            .filter((browser) => browser !== "SafariTechPreview")
-            .map((browser) =>
-              browser === "ChromeHeadless" ? "ChromeHeadlessGC" : browser
-            );
+          return availableBrowsers.filter(
+            (browser) => browser !== "SafariTechPreview"
+          );
         }
       },
     },
@@ -62,14 +60,6 @@ module.exports = function (config) {
       DockerChrome: {
         base: "ChromeHeadless",
         flags: ["--no-sandbox", "--js-flags=--expose-gc"],
-      },
-      ChromeHeadlessGC: {
-        base: "ChromeHeadless",
-        flags: ["--js-flags=--expose-gc"],
-      },
-      ChromeHeadlessGC: {
-        base: "ChromeHeadless",
-        flags: ["--js-flags=--expose-gc"],
       },
     },
   };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,22 +44,32 @@ module.exports = function (config) {
         if (process.env.INSIDE_DOCKER) {
           return ["DockerChrome"];
         } else if (process.env.CHROME_ONLY) {
-          return ["ChromeHeadless"];
+          return ["ChromeHeadlessGC"];
         } else {
           // Filtering SafariTechPreview because I am having
           // local issues and I have no idea how to fix them.
           // I know that’s not a good reason to disable tests,
           // but Safari TP is relatively unimportant.
-          return availableBrowsers.filter(
-            (browser) => browser !== "SafariTechPreview"
-          );
+          return availableBrowsers
+            .filter((browser) => browser !== "SafariTechPreview")
+            .map((browser) =>
+              browser === "ChromeHeadless" ? "ChromeHeadlessGC" : browser
+            );
         }
       },
     },
     customLaunchers: {
       DockerChrome: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox"],
+        flags: ["--no-sandbox", "--js-flags=--expose-gc"],
+      },
+      ChromeHeadlessGC: {
+        base: "ChromeHeadless",
+        flags: ["--js-flags=--expose-gc"],
+      },
+      ChromeHeadlessGC: {
+        base: "ChromeHeadless",
+        flags: ["--js-flags=--expose-gc"],
       },
     },
   };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "rollup -c",
     "test:unit": "karma start",
+    "test:unit:gc": "karma start --browsers ChromeHeadlessGC",
     "test:node": "mocha ./tests/node/main.mjs",
     "test:types": "tsc -p ./tests/tsconfig.json",
     "test:types:watch": "npm run test:types -- --watch",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "build": "rollup -c",
     "test:unit": "karma start",
-    "test:unit:gc": "karma start --browsers ChromeHeadlessGC",
     "test:node": "mocha ./tests/node/main.mjs",
     "test:types": "tsc -p ./tests/tsconfig.json",
     "test:types:watch": "npm run test:types -- --watch",

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -234,6 +234,7 @@ type PendingListenersMap = Map<
 type EndpointWithPendingListeners = {
   endpoint: Endpoint;
   pendingListeners: PendingListenersMap;
+  releaseDeferred?: boolean;
 };
 
 /**
@@ -401,6 +402,10 @@ function closeEndPoint(endpoint: Endpoint) {
 
 export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
   const pendingListeners : PendingListenersMap = new Map();
+  const epWithPendingListeners: EndpointWithPendingListeners = {
+    endpoint: ep,
+    pendingListeners,
+  };
 
   ep.addEventListener("message", function handleMessage(ev: Event) {
     const { data } = ev as MessageEvent;
@@ -416,10 +421,19 @@ export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
       resolver(data);
     } finally {
       pendingListeners.delete(data.id);
+      if (
+        epWithPendingListeners.releaseDeferred &&
+        pendingListeners.size === 0
+      ) {
+        epWithPendingListeners.releaseDeferred = false;
+        releaseEndpoint(epWithPendingListeners).finally(() => {
+          pendingListeners.clear();
+        });
+      }
     }
   });
 
-  return createProxy<T>({ endpoint: ep, pendingListeners }, [], target) as any;
+  return createProxy<T>(epWithPendingListeners, [], target) as any;
 }
 
 function throwIfProxyReleased(isReleased: boolean) {
@@ -455,6 +469,10 @@ const proxyFinalizers =
       const newCount = (proxyCounter.get(epWithPendingListeners) || 0) - 1;
       proxyCounter.set(epWithPendingListeners, newCount);
       if (newCount === 0) {
+        if (epWithPendingListeners.pendingListeners.size > 0) {
+          epWithPendingListeners.releaseDeferred = true;
+          return;
+        }
         releaseEndpoint(epWithPendingListeners).finally(() => {
           epWithPendingListeners.pendingListeners.clear();
         });

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -598,6 +598,42 @@ describe("Comlink in the same realm", function () {
     expect(finalized).to.be.true;
   });
 
+  it("in-flight requests should not be dropped when proxy is GC'd mid-await", async function () {
+    if (typeof globalThis.gc !== "function") this.skip();
+    this.timeout(15000);
+
+    const hammer = setInterval(() => globalThis.gc(), 50);
+    const garbage = [];
+    const pressure = setInterval(() => {
+      garbage.push(new Uint8Array(2_000_000));
+      if (garbage.length > 20) garbage.length = 0;
+    }, 50);
+
+    try {
+      for (let i = 0; i < 20; i++) {
+        const { port1, port2 } = new MessageChannel();
+        port1.start();
+        port2.start();
+        Comlink.expose(
+          {
+            slow: () => new Promise((r) => setTimeout(() => r("ok"), 100)),
+          },
+          port2
+        );
+        const result = await Promise.race([
+          Comlink.wrap(port1).slow(),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error(`call ${i} hung — port closed mid-await`)), 2000)
+          ),
+        ]);
+        expect(result).to.equal("ok");
+      }
+    } finally {
+      clearInterval(hammer);
+      clearInterval(pressure);
+    }
+  });
+
   // commented out this test as it could be unreliable in various browsers as
   // it has to wait for GC to kick in which could happen at any timing
   // this does seem to work when testing locally


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/comlink/issues/692

`FinalizationRegistry` cleanup currently closes the endpoint and clears `pendingListeners` without checking whether any are mid-flight, so a GC'd proxy during a long await silently drops the worker's reply and the awaiter hangs forever.

This patch defers the release while `pendingListeners.size > 0` and runs it from the message handler once they drain. No public API change.

Includes a karma test that fails in 2s when `src/comlink.ts` is reverted, passes with the change applied. Self-skips when `--js-flags=--expose-gc` isn't available.
