### PR TITLE
fix: include serialization error details

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -380,7 +380,7 @@ export function expose(
       .catch((error) => {
         // Send Serialization Error To Caller
         const [wireValue, transferables] = toWireValue({
-          value: new TypeError("Unserializable return value"),
+          value: new TypeError(getUnserializableErrorMessage(error)),
           [throwMarker]: 0,
         });
         ep.postMessage({ ...wireValue, id }, transferables);
@@ -399,8 +399,16 @@ function closeEndPoint(endpoint: Endpoint) {
   if (isMessagePort(endpoint)) endpoint.close();
 }
 
+function getUnserializableErrorMessage(error: unknown) {
+  const details = error instanceof Error ? error.message : String(error);
+
+  return details
+    ? `Unserializable return value: ${details}`
+    : "Unserializable return value";
+}
+
 export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
-  const pendingListeners : PendingListenersMap = new Map();
+  const pendingListeners: PendingListenersMap = new Map();
 
   ep.addEventListener("message", function handleMessage(ev: Event) {
     const { data } = ev as MessageEvent;
@@ -643,7 +651,7 @@ function requestResponseMessage(
       ep.start();
     }
     ep.postMessage({ id, ...msg }, transfers);
-});
+  });
 }
 
 function generateUUID(): string {

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -645,7 +645,37 @@ describe("Comlink in the same realm", function () {
     try {
       await thing.value;
     } catch (err) {
-      expect(err.message).to.equal("Unserializable return value");
+      expect(err.message).to.contain("Unserializable return value");
+    }
+  });
+
+  it("includes serialization error details for unserializable return values", async function () {
+    const transferHandlerName = "throwing-test";
+    Comlink.transferHandlers.set(transferHandlerName, {
+      canHandle(value) {
+        return value && value.throwOnSerialize === true;
+      },
+      serialize() {
+        throw new Error("custom serialization failed");
+      },
+      deserialize() {},
+    });
+
+    try {
+      const thing = Comlink.wrap(this.port1, { value: {} });
+      Comlink.expose({ value: { throwOnSerialize: true } }, this.port2);
+
+      try {
+        await thing.value;
+        throw "Should have thrown";
+      } catch (err) {
+        expect(err).to.not.equal("Should have thrown");
+        expect(err.message).to.equal(
+          "Unserializable return value: custom serialization failed"
+        );
+      }
+    } finally {
+      Comlink.transferHandlers.delete(transferHandlerName);
     }
   });
 });


### PR DESCRIPTION
## Problem
When Comlink catches an error while serializing a return value, the caller only receives `Unserializable return value`. That hides the underlying serialization error message that usually explains what could not be cloned or serialized.

## Root cause
The serialization fallback catch block discarded the caught `error` and always created the same generic `TypeError`.

## Solution
Build the fallback `TypeError` message from the caught serialization error when it has details, while keeping the existing generic prefix. Added a same-window regression test with a deterministic transfer handler that throws during serialization.

## Tests
- `npm run build`
- `npm run test:types`
- `CHROME_ONLY=1 npm run test:unit`
- `npm run test:node`
- `npm exec --yes prettier@2.8.3 -- --check src/comlink.ts tests/same_window.comlink.test.js`
- `git diff --check`

Fixes #679.