### PR TITLE
docs: clarify bidirectional Comlink patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ myProxy.onready = Comlink.proxy((data) => {
 });
 ```
 
+### Two-way communication
+
+Comlink proxies can be used for bidirectional communication, but one side has to pass the other side a proxy or endpoint explicitly. For occasional calls back to the caller, pass a callback or object with `Comlink.proxy()`. For a second long-lived proxy, use `[Comlink.createEndpoint]()` or create a separate `MessageChannel` and call `wrap()`/`expose()` on opposite ports.
+
+Avoid assuming that `wrap()` and `expose()` on their own make both sides' local objects available over the same worker. `wrap()` only talks to the value that the other side exposed, and `expose()` only makes one local value available. If both sides need to call each other, model that connection explicitly with a proxied callback, a proxied object, or another endpoint.
+
 ### Transfer handlers and event listeners
 
 It is common that you want to use Comlink to add an event listener, where the event source is on another thread:


### PR DESCRIPTION
Problem
- Closes #672.
- The README documents callbacks and endpoints separately, but does not explicitly explain how to model two-way communication.

Root cause
- `wrap()` talks to one value exposed by the other side, while `expose()` makes one local value available. Users can miss that callbacks, proxied objects, or additional endpoints are needed when both sides need to call each other.

Solution
- Add a short README section describing supported bidirectional patterns:
  - pass callbacks or objects with `Comlink.proxy()`
  - use `Comlink.createEndpoint()` or a separate `MessageChannel` for another long-lived proxy
  - avoid assuming `wrap()` and `expose()` alone expose both local object graphs

Tests run
- `npx prettier@2.8.3 --check README.md`
- `git diff --check`