### PR TITLE
Support nested object graph access in Remote types

### DIFF
--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -53,9 +53,13 @@ type Unpromisify<P> = P extends Promise<infer T> ? T : P;
  */
 type RemoteProperty<T> =
   // If the value is a method, comlink will proxy it automatically.
-  // Objects are only proxied if they are marked to be proxied.
+  // Objects can be either awaited as cloned values or traversed as remote paths.
   // Otherwise, the property is converted to a Promise that resolves the cloned value.
-  T extends Function | ProxyMarked ? Remote<T> : Promisify<T>;
+  T extends Function | ProxyMarked
+    ? Remote<T>
+    : T extends object
+    ? Remote<T> & Promisify<T>
+    : Promisify<T>;
 
 /**
  * Takes the raw type of a property as a remote thread would see it through a proxy (e.g. when passed in as a function
@@ -400,7 +404,7 @@ function closeEndPoint(endpoint: Endpoint) {
 }
 
 export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
-  const pendingListeners : PendingListenersMap = new Map();
+  const pendingListeners: PendingListenersMap = new Map();
 
   ep.addEventListener("message", function handleMessage(ev: Event) {
     const { data } = ev as MessageEvent;
@@ -643,7 +647,7 @@ function requestResponseMessage(
       ep.start();
     }
     ep.postMessage({ id, ...msg }, transfers);
-});
+  });
 }
 
 function generateUUID(): string {

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -87,9 +87,27 @@ async function closureSoICanUseAwait() {
     assert<IsAny<typeof b>>(false);
     const subproxy = proxy.c;
     assert<Has<typeof subproxy, Promise<{ d: number }>>>(true);
+    assert<Has<typeof subproxy, { d: Promise<number> }>>(true);
     assert<IsAny<typeof subproxy>>(false);
     const copy = await proxy.c;
     assert<Has<typeof copy, { d: number }>>(true);
+
+    const nestedValue = proxy.c.d;
+    assert<Has<typeof nestedValue, Promise<number>>>(true);
+  }
+
+  {
+    interface WorkerApi {
+      service: {
+        method: () => void;
+      };
+    }
+
+    const proxy = Comlink.wrap<WorkerApi>(0 as any);
+    const call = proxy.service.method();
+    assert<Has<typeof call, Promise<void>>>(true);
+    const service = await proxy.service;
+    assert<Has<typeof service, { method: () => void }>>(true);
   }
 
   {


### PR DESCRIPTION
Fixes #680.

## Problem
`RemoteProperty<T>` currently types unmarked object properties only as `Promise<T>`. At runtime, those properties can also be traversed as remote proxy paths, so `proxy.service.method()` works but TypeScript rejects it.

## Root cause
The conditional type collapses every non-function, non-`ProxyMarked` property to `Promisify<T>`, which loses the nested remote object surface.

## Solution
For object properties, expose an intersection of `Remote<T>` and `Promise<T>`. This keeps `await proxy.service` typed as the cloned object while also typing `proxy.service.method()` and other nested proxy-path access.

## Tests
- `npm run test:types`
- `npm run build`
- `npm run test:node`
- `npx prettier --check src/comlink.ts tests/type-checks.ts`
- `git diff --check`